### PR TITLE
build: upgrade OkHttp to 5.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,7 @@ val sourceCommit = System.getenv("MOTD_SOURCE_COMMIT")
 
 android {
     namespace = "io.github.trevarj.motd"
-    compileSdk = 35
+    compileSdk = 36
 
     // F-Droid rejects AGP's dependency metadata APK signing block. Dependency provenance is
     // pinned and published separately through the fdroiddata recipe and release source bundle.

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
         };
         # Match compileSdk/buildTools used by the current Gradle configuration.
         androidComposition = pkgs.androidenv.composeAndroidPackages {
-          platformVersions = [ "35" ];
+          platformVersions = [ "36" ];
           buildToolsVersions = [ "36.0.0" ];
           platformToolsVersion = "35.0.2";
           includeEmulator = false;
@@ -39,7 +39,7 @@
         # Opt-in, large emulator closure for the local headless E2E loop. Keeping this separate
         # avoids making every ordinary build fetch an API image and emulator runtime.
         emulatorComposition = pkgs.androidenv.composeAndroidPackages {
-          platformVersions = [ "34" ];
+          platformVersions = [ "34" "36" ];
           buildToolsVersions = [ "36.0.0" ];
           platformToolsVersion = "35.0.2";
           includeEmulator = true;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,8 @@ paging = "3.5.0"
 datastore = "1.2.1"
 coil = "2.7.0"
 okio = "3.17.0"
-# Pinned to the version Coil 2.7.0 already resolves transitively (verified via :app:dependencies),
-# so adding okhttp explicitly for the WSS transport (plans/19) introduces no new resolved version.
-okhttp = "4.12.0"
+# Explicit runtime pin for the WSS transport and MockWebServer-backed tests.
+okhttp = "5.4.0"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 # plans/01 pins 2.4.0, but that version was never published to Maven Central


### PR DESCRIPTION
Splits the OkHttp update out of #12 after the AGP 9 toolchain migration.\n\n- upgrades OkHttp and MockWebServer to 5.4.0\n- raises compileSdk to 36 as required by okhttp-android 5.4.0 AAR metadata\n- adds API 36 to the pinned Nix SDKs while retaining the API 34 emulator image\n- keeps minSdk 26, targetSdk 35, and existing networking boundaries unchanged\n- verifies Coil\u0027s OkHttp 4 request resolves to 5.4.0\n\nValidation: focused WebSocket/MockWebServer tests and a clean full documented FOSS release-parity gate passed locally; E2E static validation passed (Docker-only Compose validation unavailable locally).