### PR TITLE
build: upgrade Okio to 3.18.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ room = "2.8.4"
 paging = "3.5.0"
 datastore = "1.2.1"
 coil = "2.7.0"
-okio = "3.17.0"
+okio = "3.18.0"
 # Explicit runtime pin for the WSS transport and MockWebServer-backed tests.
 okhttp = "5.4.0"
 coroutines = "1.11.0"


### PR DESCRIPTION
Replaces stale grouped Dependabot PR #20 after its AndroidX updates landed through #19.\n\nThis leaves the actual remaining delta only: Okio 3.17.0 to 3.18.0.\n\nValidation: clean IRC and FOSS app tests, lint, release assembly, dependency resolution, and E2E static validation passed locally (Docker-only Compose validation unavailable locally).