### PR TITLE
perf: cut build/test turnaround (drop ~30x lint workaround, cache CI toolchain)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -21,7 +21,7 @@ FOSS lint and debug assembly:
 ```sh
 nix develop -c ./gradlew \
   :app:lintFossDebug :app:assembleFossDebug \
-  --stacktrace --no-daemon --max-workers=1
+  --stacktrace
 ```
 
 Full release-parity Gradle verification:
@@ -31,14 +31,18 @@ nix develop .#native -c ./gradlew \
   :irc:build \
   :app:testFossDebugUnitTest :app:testFossReleaseUnitTest \
   :app:lintFossDebug :app:lintFossRelease :app:assembleFossRelease \
-  --stacktrace --no-daemon --max-workers=1
+  --stacktrace
 ```
 
 The Google/FCM flavor is dormant. Do not run Google Gradle tasks or build a
 Google APK unless the maintainer explicitly reactivates that distribution.
 
-Lint warnings are errors. Keep the single-worker/no-daemon form for final lint
-and release checks because it avoids a known Android lint worker race.
+Lint warnings are errors. Run with the warm daemon and the repo's bounded worker
+cap (`org.gradle.workers.max` in `gradle.properties`); do not add
+`--no-daemon --max-workers=1`, which cost ~30x the wall-clock for no deterministic
+protection. Lint can still rarely hit the `ModifierDeclarationDetector`
+classloader race; just re-run (the warm daemon makes the retry ~10s). Required CI
+and release both wrap lint in a bounded retry for the same reason.
 
 ## Deterministic generated tests
 
@@ -57,6 +61,13 @@ effective counts, index ranges, and any manual overrides.
 - `MOTD_FUZZ_CASE=<index>` replays one independently seeded case.
 - `MOTD_FUZZ_PROFILE=pr|nightly` selects the bounded workload.
 - `MOTD_FUZZ_CASES=<count>` and `MOTD_FUZZ_STEPS=<count>` override campaign size.
+  Only positive values apply (`0` is ignored and falls back to the profile), so
+  the minimum is `1`. For the tightest inner loop when iterating on code
+  unrelated to the fuzzed surfaces, run e.g.
+  `MOTD_FUZZ_CASES=1 MOTD_FUZZ_STEPS=1 ./gradlew :app:testFossDebugUnitTest` to
+  shrink the generated campaign to a single case; the committed regression corpus
+  still runs. Never commit that reduced profile; leave the CI/default counts
+  intact so coverage is not silently lost.
 - `MOTD_FUZZ_SHARD=<zero-based index>` offsets generated case indices by one
   configured case-count, allowing parallel jobs to cover disjoint cases under
   the same reproducible seed. Exact `MOTD_FUZZ_CASE` replay ignores the shard.

--- a/.github/actions/setup-native-toolchain/action.yml
+++ b/.github/actions/setup-native-toolchain/action.yml
@@ -4,6 +4,34 @@ description: Install and expose the exact Android NDK pinned for libbox and APK 
 runs:
   using: composite
   steps:
+    # Resolve the pinned package paths in a shell step: the ${{ env }} context in
+    # a composite action does not see runner-set variables like ANDROID_HOME, so
+    # the cache path must be produced here rather than referenced inline.
+    - name: Resolve pinned toolchain paths
+      id: paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source third_party/sing-box/source.lock
+        {
+          echo "cache_paths<<EOF"
+          echo "$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
+          echo "$ANDROID_HOME/platforms/android-23"
+          echo "$ANDROID_HOME/platforms/android-37.0"
+          echo "$ANDROID_HOME/build-tools/36.0.0"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+    # Cache the ~1GB NDK plus the pinned platforms/build-tools. The key hashes
+    # both source.lock (NDK version) and this action (the platform/build-tools
+    # list), so any pin change invalidates the cache automatically.
+    - name: Cache pinned Android NDK/SDK packages
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ${{ steps.paths.outputs.cache_paths }}
+        key: android-toolchain-${{ runner.os }}-${{ hashFiles('third_party/sing-box/source.lock', '.github/actions/setup-native-toolchain/action.yml') }}
+    # Idempotent: a no-op on a cache hit, and the source of truth that populates
+    # the cache on a miss. Always runs so ANDROID_NDK_HOME is exported either way.
     - name: Install pinned Android SDK packages
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: App unit tests (debug and release)
         run: >-
           ./gradlew :app:testFossDebugUnitTest :app:testFossReleaseUnitTest
-          --stacktrace --no-daemon --max-workers=1
+          --stacktrace
       - name: Upload app generated-test failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -76,16 +76,17 @@ jobs:
             echo "Google-only dependencies reached the FOSS runtime classpath" >&2
             exit 1
           fi
-      # Lint runs isolated with a single worker and no daemon to avoid the
-      # flaky Gradle-worker classloader race that surfaces as
-      # NoClassDefFoundError in ModifierDeclarationDetector. A bounded retry
-      # (2 attempts) covers the rare case it still races.
+      # Lint occasionally hits a rare Gradle-worker classloader race that
+      # surfaces as NoClassDefFoundError in ModifierDeclarationDetector. The old
+      # --no-daemon --max-workers=1 guard never fully prevented it (hence this
+      # retry) while costing ~30x the wall-clock, so lint now runs with the warm
+      # daemon and the repo's bounded worker cap; the bounded retry (2 attempts,
+      # each now sharing the daemon) is the actual safety net for the rare race.
       - name: Android lint (warnings as errors)
         run: |
           for attempt in 1 2; do
             echo "::group::lint attempt $attempt"
-            ./gradlew :app:lintFossDebug :app:lintFossRelease \
-              --stacktrace --no-daemon --max-workers=1 \
+            ./gradlew :app:lintFossDebug :app:lintFossRelease --stacktrace \
               && { echo "::endgroup::"; exit 0; }
             echo "::endgroup::"
             echo "lint attempt $attempt failed; retrying" >&2
@@ -94,7 +95,7 @@ jobs:
       - name: Assemble debug and release APKs
         run: >-
           ./gradlew :app:assembleFossDebug :app:assembleFossRelease
-          --stacktrace --no-daemon --max-workers=1
+          --stacktrace
       - name: Validate E2E shell and Compose configuration
         run: ./test/e2e/validate.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -115,6 +116,28 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      # Cache the AVD + a warm boot snapshot so runs load a snapshot instead of
+      # cold-booting. Key covers every dimension that changes the image/AVD.
+      - name: AVD cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-default-x86_64-pixel6
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 34
+          target: default
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          disable-animations: false
+          emulator-options: -no-window -noaudio -no-boot-anim -gpu swiftshader_indirect
+          script: echo "Generated AVD snapshot for caching."
       - name: Start hermetic bouncer stack
         run: ./test/e2e/hermetic-stack.sh up
       - name: Run required isolated journeys
@@ -124,8 +147,11 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_6
+          force-avd-creation: false
           disable-animations: true
-          emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim -gpu swiftshader_indirect
+          # Load the cached snapshot; -no-snapshot-save keeps the cache immutable
+          # across runs (replaces the old cold-boot -no-snapshot).
+          emulator-options: -no-window -no-snapshot-save -noaudio -no-boot-anim -gpu swiftshader_indirect
           script: ./test/e2e/fast-suite.sh connected
       - name: Upload privacy-safe required diagnostics
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           }
           printf 'MOTD_VERSION_NAME=%s\nMOTD_VERSION_CODE=%s\nMOTD_SOURCE_COMMIT=%s\n' \
             "$version_name" "$version_code" "$GITHUB_SHA" >> "$GITHUB_ENV"
-      - name: Full build, tests, lint, and signed release APK
+      - name: Full build, tests, and signed release APK
         env:
           MOTD_KEYSTORE_PATH: ${{ runner.temp }}/keystore.jks
           MOTD_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -46,8 +46,20 @@ jobs:
         run: >-
           ./gradlew :irc:build
           :app:testFossDebugUnitTest :app:testFossReleaseUnitTest
-          :app:lintFossDebug :app:lintFossRelease :app:assembleFossRelease
-          --stacktrace --no-daemon --max-workers=1
+          :app:assembleFossRelease
+          --stacktrace
+      # Lint is split out with a bounded retry: it can rarely hit the
+      # ModifierDeclarationDetector classloader race, and unlike required CI the
+      # release job has no other retry. Warm daemon + bounded workers keep each
+      # attempt fast (the old --no-daemon --max-workers=1 cost ~30x for no
+      # deterministic race protection).
+      - name: Android lint (warnings as errors)
+        run: |
+          for attempt in 1 2; do
+            ./gradlew :app:lintFossDebug :app:lintFossRelease --stacktrace && exit 0
+            echo "lint attempt $attempt failed; retrying" >&2
+          done
+          exit 1
       - name: Verify F-Droid-compatible APK signing blocks
         run: >-
           java .github/scripts/CheckApkSigningBlocks.java

--- a/docs/human-developing.md
+++ b/docs/human-developing.md
@@ -39,18 +39,21 @@ verified libbox artifact.
 
 ## Lint
 
-Lint warnings are errors. Use the single-worker, no-daemon form for final lint
-checks because it avoids a known Android lint worker race.
+Lint warnings are errors. Run with the warm daemon and the repo's bounded worker
+cap (`org.gradle.workers.max` in `gradle.properties`). Do not add
+`--no-daemon --max-workers=1`: it cost roughly 30x the wall-clock (~300s vs ~10s
+warm) for no deterministic race protection. Lint can rarely hit the
+`ModifierDeclarationDetector` classloader race; if it does, just re-run (the warm
+daemon makes a re-run ~10s). CI and release wrap lint in a bounded retry.
 
 ```sh
-./gradlew :app:lintFossDebug :app:assembleFossDebug \
-  --stacktrace --no-daemon --max-workers=1
+./gradlew :app:lintFossDebug :app:assembleFossDebug --stacktrace
 ```
 
 For release parity:
 
 ```sh
-./gradlew :app:lintFossRelease --stacktrace --no-daemon --max-workers=1
+./gradlew :app:lintFossRelease --stacktrace
 ```
 
 ## Choose checks by changed surface
@@ -76,7 +79,7 @@ Full release-parity Gradle verification:
   :irc:build \
   :app:testFossDebugUnitTest :app:testFossReleaseUnitTest \
   :app:lintFossDebug :app:lintFossRelease :app:assembleFossRelease \
-  --stacktrace --no-daemon --max-workers=1
+  --stacktrace
 ```
 
 ## Device and E2E testing

--- a/docs/human-releasing.md
+++ b/docs/human-releasing.md
@@ -90,7 +90,7 @@ creating or changing it, reload direnv and build the supported FOSS release:
 ```sh
 direnv allow
 MOTD_SOURCE_COMMIT="$(git rev-parse HEAD)" \
-  ./gradlew :app:assembleFossRelease --no-daemon --max-workers=1
+  ./gradlew :app:assembleFossRelease
 ```
 
 The signed APK is

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,13 @@
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+# Keep the daemon warm and parallelize the module/variant graph. Workers are
+# capped well below the 12-thread CPU: the dev box has 14 GiB RAM (swap-heavy at
+# idle) and each worker fork plus the -Xmx4g daemon competes with a resident
+# emulator during E2E. Four fits the standalone headroom; E2E assembles pass an
+# explicit --max-workers=2 when the emulator is co-resident.
+org.gradle.parallel=true
+org.gradle.workers.max=4
 android.useAndroidX=true
 # Preserve debug and release unit-test components under AGP 9.
 android.onlyEnableUnitTestForTheTestedBuildType=false

--- a/test/e2e/component-suite.sh
+++ b/test/e2e/component-suite.sh
@@ -8,10 +8,11 @@ EXPECTED_CASES=64
 REAL_STACK_ANNOTATION=io.github.trevarj.motd.FastHeadlessE2e
 
 cd "$REPO"
+# Daemon on; --max-workers=2 because the managed device boots its own emulator.
 ./gradlew headlessApi34FossE2eAndroidTest \
   "-Pandroid.testInstrumentationRunnerArguments.notAnnotation=$REAL_STACK_ANNOTATION" \
   -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
-  --stacktrace --no-daemon --max-workers=1
+  --stacktrace --max-workers=2
 
 count="$(find "$REPO/app/build/outputs/androidTest-results" -type f -name '*.xml' -mmin -15 -print0 2>/dev/null \
   | xargs -0 -r grep -ho '<testcase ' | wc -l | tr -d ' ')"

--- a/test/e2e/fast-suite.sh
+++ b/test/e2e/fast-suite.sh
@@ -89,7 +89,9 @@ run_direct_suite() {
   local -a methods
   app_apk="${FAST_E2E_APP_APK:-$REPO/app/build/outputs/apk/foss/e2e/app-foss-e2e.apk}"
   test_apk="${FAST_E2E_TEST_APK:-$REPO/app/build/outputs/apk/androidTest/foss/e2e/app-foss-e2e-androidTest.apk}"
-  "$REPO/gradlew" :app:assembleFossE2e :app:assembleFossE2eAndroidTest --stacktrace --no-daemon --max-workers=1
+  # Daemon on for warm rebuilds; --max-workers=2 because the emulator + native
+  # stack are already resident and competing for the 14 GiB box's RAM.
+  "$REPO/gradlew" :app:assembleFossE2e :app:assembleFossE2eAndroidTest --stacktrace --max-workers=2
   e2e_adb install -r -g "$app_apk" >/dev/null
   e2e_adb install -r "$test_apk" >/dev/null
   runner="$(e2e_adb shell pm list instrumentation | sed -n "s#^instrumentation:\([^ ]*\) (target=${FAST_E2E_TARGET_PACKAGE})#\1#p" | head -1 | tr -d '\r')"

--- a/test/e2e/headless.sh
+++ b/test/e2e/headless.sh
@@ -78,8 +78,13 @@ boot_emulator() {
   fi
   ensure_avd
   log "booting $AVD_NAME as $SERIAL"
+  # Quickboot: load the named snapshot when present and save it on the clean
+  # `adb emu kill` in down(). The first boot has no snapshot and cold-boots (the
+  # 120s wait below still guards); every boot after a reboot or `down` restores
+  # the snapshot instead of paying a full cold boot. App state is irrelevant to
+  # the snapshot because fast-suite reinstalls the APKs and pm-clears per method.
   setsid emulator "@$AVD_NAME" -port "$EMULATOR_PORT" -no-window -noaudio \
-    -no-boot-anim -gpu swiftshader_indirect >"$LOG_FILE" 2>&1 &
+    -no-boot-anim -gpu swiftshader_indirect -snapshot default-boot >"$LOG_FILE" 2>&1 &
   printf '%s\n' "$!" >"$PID_FILE"
   printf '%s\n' "$SERIAL" >"$SERIAL_FILE"
 
@@ -182,7 +187,7 @@ full() {
   up
   log "building shell-runbook E2E APK"
   nix develop "$REPO" -c ./gradlew :app:assembleFossE2e \
-    --stacktrace --no-daemon --max-workers=1
+    --stacktrace --max-workers=2
   ANDROID_SERIAL="$SERIAL" SERIAL="$SERIAL" \
     MOTD_PKG=io.github.trevarj.motd.debug \
     MOTD_APK="$REPO/app/build/outputs/apk/foss/e2e/app-foss-e2e.apk" \
@@ -206,7 +211,7 @@ showcase() {
   up
   log "building showcase E2E APK"
   nix develop "$REPO" -c ./gradlew :app:assembleFossE2e \
-    --stacktrace --no-daemon --max-workers=1
+    --stacktrace --max-workers=2
   log "capturing public showcase screenshots into $screenshot_dir"
   ANDROID_SERIAL="$SERIAL" SERIAL="$SERIAL" \
     MOTD_PKG=io.github.trevarj.motd.debug \


### PR DESCRIPTION
## Why

Turnaround on change → validate was dominated by one flag pair —
`--no-daemon --max-workers=1` — copy-pasted onto **every** heavy Gradle task
(unit tests, lint, assemble, E2E builds) to dodge a rare lint
`ModifierDeclarationDetector` classloader race.

A reproduction matrix on the dev box (Ryzen 5 7540U, 6c/12t, 14 GiB):

| Config | Time |
|---|---|
| Current workaround (`--no-daemon --max-workers=1`, both lint variants) | **309s** |
| Daemon on, full workers, both variants | **18s cold → 9–10s warm** |

The race **did not reproduce** in 4 runs at max parallelism + daemon. Combined
with the fact that the CI retry loop existed precisely because `--max-workers=1`
never fully prevented it, the workaround cost ~30x for no deterministic
protection. The correct fix is **daemon on + bounded workers + keep the (now
~10s) retry** as the backstop.

## What

**Build/test (validated locally):**
- `gradle.properties`: `org.gradle.parallel=true`, memory-aware
  `org.gradle.workers.max=4` (peak swap stayed flat, ~4.9 GiB free during a full
  release-parity run).
- Strip the flags everywhere; E2E assembles use `--max-workers=2` (emulator
  co-resident). Warm incremental lint+assembleDebug now ~10s (was ~300s cold).
- `headless.sh`: AVD quickboot so post-reboot/`down` loads a snapshot.
- `release.yml`: split lint into a bounded retry.
- Docs + a `MOTD_FUZZ_CASES=1` tight-inner-loop note.

**Required CI caching:**
- `setup-native-toolchain`: cache the ~1GB NDK/SDK (keyed on source.lock).
- `headless` job: AVD snapshot cache + `-no-snapshot-save` (was cold
  `-no-snapshot`); daemon shared across the app job's steps.

## Validation

- Full release-parity `./gradlew :irc:build :app:test{Foss,Debug,Release}… lint… assembleFossRelease` → **BUILD SUCCESSFUL**, memory-safe.
- `actionlint` clean on all workflows.
- CI-side caching (NDK/AVD) needs this PR's run to confirm at runtime.

## Deliberately NOT included (findings)

- **APK artifact sharing**: no net benefit in this topology — only `headless`
  could consume a prebuilt APK; `component-ui` uses a Gradle managed-device task
  that builds internally. Making `headless` depend on the APK build just
  serializes it. Real cross-job compile dedup needs a shared Gradle build cache.
- **Docker build cache**: requires editing shared `docker-compose.yml`/
  `hermetic-stack.sh` (used by local iteration + nightly e2e), modest payoff
  (soju Go build). Better decided against this PR's real CI timings.

Draft: opening for the required CI to validate the caching at runtime.