### PR TITLE
fix(irc): accept a labeled-response wrapper around CHATHISTORY batches

### DIFF
--- a/irc/src/main/kotlin/io/github/trevarj/motd/irc/client/IrcClient.kt
+++ b/irc/src/main/kotlin/io/github/trevarj/motd/irc/client/IrcClient.kt
@@ -888,18 +888,32 @@ class IrcClient(
         }
         val root = response.rootBatch
             ?: throw IrcProtocolException("CHATHISTORY", "response did not contain a complete root batch")
+        // Two accepted shapes, matching `search`: released soju sends a bare `chathistory` root,
+        // while soju master (post-70c4ded) wraps that batch in an outer `labeled-response` batch.
+        // In the wrapped shape the label opens the wrapper and the history batch sits one level in,
+        // so rejecting it would turn a server upgrade into silently broken scrollback.
+        // Unlike `search`, only the first batch inside the wrapper is the history batch: multiline
+        // and netsplit batches nest within it rather than beside it, so they must not be matched
+        // here. They are reassembled later by `mapCorrelatedHistory`, which walks the wrapper.
+        val hist = if (root.params.getOrNull(1).orEmpty().equals("labeled-response", ignoreCase = true)) {
+            response.messages.firstOrNull {
+                it.command == "BATCH" && it.params.firstOrNull()?.startsWith("+") == true
+            } ?: throw IrcProtocolException("CHATHISTORY", "labeled-response wrapper contained no batch")
+        } else {
+            root
+        }
         val expectedType = if (req.subcommand == ChatHistoryRequest.Subcommand.TARGETS) {
             "draft/chathistory-targets"
         } else {
             "chathistory"
         }
-        if (root.command != "BATCH" || !root.params.getOrNull(1).orEmpty().equals(expectedType, ignoreCase = true)) {
+        if (hist.command != "BATCH" || !hist.params.getOrNull(1).orEmpty().equals(expectedType, ignoreCase = true)) {
             throw IrcProtocolException(
                 "CHATHISTORY",
-                "unexpected batch type ${root.params.getOrNull(1).orEmpty()}",
+                "unexpected batch type ${hist.params.getOrNull(1).orEmpty()}",
             )
         }
-        val endOfHistory = "draft/chathistory-end" in root.tags
+        val endOfHistory = "draft/chathistory-end" in hist.tags
         return if (req.subcommand == ChatHistoryRequest.Subcommand.TARGETS) {
             ChatHistoryResponse.Targets(parseTargets(response.messages), endOfHistory)
         } else {

--- a/irc/src/test/kotlin/io/github/trevarj/motd/irc/client/IrcClientTest.kt
+++ b/irc/src/test/kotlin/io/github/trevarj/motd/irc/client/IrcClientTest.kt
@@ -546,6 +546,36 @@ class IrcClientTest {
     }
 
     @Test
+    fun `labeled chathistory accepts a labeled-response wrapper`() = runTest {
+        val ft = FakeTransport()
+        val client = registered(ft)
+
+        val result = clientScope().async {
+            client.chathistory(
+                ChatHistoryRequest(ChatHistoryRequest.Subcommand.LATEST, "#chan", limit = 50),
+            )
+        }
+        runCurrent()
+
+        val label = responseLabel(ft.sent.last { it.contains("CHATHISTORY") })
+
+        ft.feed("@label=$label BATCH +wrap labeled-response")
+        ft.feed("@batch=wrap;draft/chathistory-end BATCH +hist chathistory #chan")
+        ft.feed("@batch=hist :a!u@h PRIVMSG #chan :first")
+        ft.feed("@batch=hist :b!u@h PRIVMSG #chan :second")
+        ft.feed("@batch=wrap BATCH -hist")
+        ft.feed("BATCH -wrap")
+        runCurrent()
+
+        val res = result.await() as ChatHistoryResponse.Messages
+        assertTrue(res.endOfHistory)
+        assertEquals(
+            listOf("first", "second"),
+            res.events.filterIsInstance<IrcEvent.ChatMessage>().map { it.text },
+        )
+    }
+
+    @Test
     fun `labeled chathistory reconstructs nested multiline message`() = runTest {
         val ft = FakeTransport()
         val client = registered(ft, multilineLs)


### PR DESCRIPTION
## Problem

soju master (post-`70c4ded`) wraps labeled replies in an outer `labeled-response`
batch. The label then opens the *wrapper*, and the actual `chathistory` batch sits
one level in.

`chathistory()` compared the root batch's type directly against the expected
`chathistory` / `draft/chathistory-targets`, so against a wrapping server it saw
`labeled-response` and threw:

```
IrcProtocolException("CHATHISTORY", "unexpected batch type labeled-response")
```

Every scrollback fetch fails on that path, so a server upgrade turns into silently
broken history with no client-side change to explain it.

`search()` already handles this exact wrapper (`IrcClient.kt`, "Two accepted
shapes" — same soju commit). This applies the same tolerance to CHATHISTORY.

## Change

If the root batch's type is `labeled-response`, unwrap to the first batch opened
inside it and validate *that* against the expected type; otherwise the root is used
unchanged. The type check and the `draft/chathistory-end` tag read both move from
the root batch to the unwrapped one.

Unwrapped responses take an identical path to before — the released-soju shape is
untouched.

### Why the first inner batch, rather than `search`'s stricter rule

`search()` rejects a wrapper containing *any* batch that isn't `soju.im/search`.
That rule would be wrong here: multiline and netsplit batches legitimately nest
*inside* a history batch. Only the first batch opened in the wrapper is the history
batch; the rest are reassembled by `mapCorrelatedHistory`, which walks the wrapper
tree and recurses through intermediate nesting. The divergence is deliberate and
commented at the call site.

## Notes for review

Two things that look like bugs on a cold read but are load-bearing:

- **The inner-batch scan can't match the wrapper itself.** `LabelCorrelator.route`
  sets `pending.rootBatch` and returns *before* buffering, so the root BATCH open
  line never enters `response.messages`. Nested opens are buffered, so the scan
  only ever sees inner batches.
- **`mapCorrelatedHistory` still receives `root`, not the unwrapped batch.** This is
  correct: it builds the tree from the wrapper, and `mapCorrelatedHistoryChildren`
  recurses through any nested batch that isn't multiline/netsplit/netjoin, making
  the extra level transparent. Passing the unwrapped batch would drop the wrapper
  framing the assembler expects.

## Testing

- `./gradlew :irc:test` — 71 tests, 0 failures.
- New: `labeled chathistory accepts a labeled-response wrapper` — feeds the wrapped
  shape (`BATCH +wrap labeled-response` → `BATCH +hist chathistory`) and asserts
  both message reassembly and that `draft/chathistory-end` is read off the inner
  batch.
- The two existing labeled-chathistory tests cover the unwrapped shape and still
  pass, confirming released soju is unaffected.
- `./gradlew :app:lintDebug` — 0 errors, 0 warnings (3 pre-existing hints in
  Compose UI files, none in code this change touches).
- `./gradlew :app:assembleDebug` — succeeds.
- Manually verified on a physical device: a debug build off this branch loads
  scrollback correctly against a live bouncer that sends the wrapped shape, which
  is the case that failed before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
