### PR TITLE
Reserve keyboard space on the network setup/settings screens

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/NetworkSettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -187,6 +188,7 @@ fun NetworkSettingsContent(
                         .fillMaxWidth()
                         .widthIn(max = 720.dp)
                         .verticalScroll(rememberScrollState())
+                        .imePadding()
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -136,6 +137,7 @@ fun AddNetworkContent(
                         .fillMaxWidth()
                         .widthIn(max = 720.dp)
                         .verticalScroll(rememberScrollState())
+                        .imePadding()
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {


### PR DESCRIPTION
## Summary
- Add `imePadding()` to the scrollable content in `AddNetworkScreen` and `NetworkSettingsScreen` so the soft keyboard no longer covers form fields/content — the screen now stays scrollable to reach whatever's underneath the keyboard instead of it being visually stuck behind it.

## Test plan
- Built debug APK, opened Settings → Add Network, focused fields near the bottom of the form with the keyboard open, confirmed the content area now resizes and is scrollable above the keyboard.
- Long-pressed an existing network → Network settings, confirmed the same for that screen's content.