### PR TITLE
Render mIRC formatting codes in chat and channel topics

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
@@ -744,7 +744,12 @@ private fun ChannelHeader(
                 val topic = buffer.topic?.takeIf { it.isNotBlank() }
                 if (topic != null) {
                     Text(
-                        text = topic,
+                        text =
+                            io.github.trevarj.motd.ui.components.linkifiedBody(
+                                text = topic,
+                                linkColor = MaterialTheme.colorScheme.primary,
+                                mentionsActive = false,
+                            ),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.weight(1f, fill = false).testTag("channelinfo_topic"),

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channellist/ChannelListScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channellist/ChannelListScreen.kt
@@ -318,7 +318,11 @@ private fun ChannelList(
                 supportingContent = {
                     if (listing.topic.isNotBlank()) {
                         Text(
-                            listing.topic,
+                            io.github.trevarj.motd.ui.components.linkifiedBody(
+                                text = listing.topic,
+                                linkColor = MaterialTheme.colorScheme.primary,
+                                mentionsActive = false,
+                            ),
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
@@ -407,14 +407,17 @@ fun ChatListRowItem(
                     text =
                         when (preview) {
                             is ChatListMessagePreview.Text -> {
-                                preview.value
+                                io.github.trevarj.motd.ui.components
+                                    .mircFormattedText(preview.value)
                             }
 
                             is ChatListMessagePreview.Voice -> {
-                                buildString {
-                                    append(stringResource(R.string.chatlist_voice_message))
-                                    preview.durationMs?.let { append(" · ${formatAudioDuration(it)}") }
-                                }
+                                androidx.compose.ui.text.AnnotatedString(
+                                    buildString {
+                                        append(stringResource(R.string.chatlist_voice_message))
+                                        preview.durationMs?.let { append(" · ${formatAudioDuration(it)}") }
+                                    },
+                                )
                             }
                         },
                     style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
@@ -1609,8 +1609,10 @@ internal fun linkifiedBody(
     codeColor: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
 ): AnnotatedString {
     // Most chat rows are plain text. Avoid the URL regex, nick token walk, and builder allocation
-    // when neither link annotations nor mention styling can affect the result.
-    if (!mentionsActive && !text.contains("http://") && !text.contains("https://") && !text.contains('`')) {
+    // when neither link annotations, mention styling, nor mIRC formatting can affect the result.
+    if (!mentionsActive && !text.contains("http://") && !text.contains("https://") && !text.contains('`') &&
+        text.none { it.code in 0x01..0x1F }
+    ) {
         return AnnotatedString(text)
     }
     return buildAnnotatedString {
@@ -1630,7 +1632,10 @@ internal fun linkifiedBody(
     }
 }
 
-/** Code segmentation precedes URL and mention annotation, so code contents stay inert. */
+/**
+ * mIRC formatting codes are resolved first since they can wrap around code spans/URLs/mentions;
+ * code segmentation then precedes URL and mention annotation so code contents stay inert.
+ */
 internal fun androidx.compose.ui.text.AnnotatedString.Builder.appendRichText(
     text: String,
     plainStyle: SpanStyle,
@@ -1638,19 +1643,24 @@ internal fun androidx.compose.ui.text.AnnotatedString.Builder.appendRichText(
     codeStyle: SpanStyle,
     mentionColor: (String) -> androidx.compose.ui.graphics.Color? = { null },
 ) {
-    for (segment in parseInlineCode(text)) {
-        when (segment) {
-            is InlineTextSegment.Code -> {
-                withStyle(codeStyle) { append(segment.text) }
-            }
+    for (run in parseMircFormatting(text)) {
+        val runPlainStyle = plainStyle.merge(run.style)
+        val runLinkStyle = run.style.merge(linkStyle)
+        val runCodeStyle = run.style.merge(codeStyle)
+        for (segment in parseInlineCode(run.text)) {
+            when (segment) {
+                is InlineTextSegment.Code -> {
+                    withStyle(runCodeStyle) { append(segment.text) }
+                }
 
-            is InlineTextSegment.Plain -> {
-                appendPlainLinksAndMentions(
-                    segment.text,
-                    plainStyle,
-                    linkStyle,
-                    mentionColor,
-                )
+                is InlineTextSegment.Plain -> {
+                    appendPlainLinksAndMentions(
+                        segment.text,
+                        runPlainStyle,
+                        runLinkStyle,
+                        mentionColor,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MircFormatting.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MircFormatting.kt
@@ -1,0 +1,201 @@
+package io.github.trevarj.motd.ui.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+
+private const val CH_BOLD = '\u0002'
+private const val CH_COLOR = '\u0003'
+private const val CH_ITALIC = '\u001D'
+private const val CH_UNDERLINE = '\u001F'
+private const val CH_STRIKETHROUGH = '\u001E'
+private const val CH_MONOSPACE = '\u0011'
+private const val CH_REVERSE = '\u0016'
+private const val CH_RESET = '\u000F'
+
+/**
+ * mIRC's original 16-color palette (codes 0-15), the only range every IRC client and bouncer is
+ * guaranteed to render consistently. Codes 16-98 (HexChat's later "256-color" extension) are
+ * parsed and stripped like any other color code so the digits never leak into the message body,
+ * but are not mapped to a color: that extended palette isn't part of the original mIRC spec, isn't
+ * consistently implemented across clients, and no source of truth for its exact RGB values is
+ * reliable enough to hardcode here without risking silently wrong colors.
+ */
+private val MIRC_COLORS_16 =
+    intArrayOf(
+        0xFFFFFFFF.toInt(),
+        0xFF000000.toInt(),
+        0xFF00007F.toInt(),
+        0xFF009300.toInt(),
+        0xFFFF0000.toInt(),
+        0xFF7F0000.toInt(),
+        0xFF9C009C.toInt(),
+        0xFFFC7F00.toInt(),
+        0xFFFFFF00.toInt(),
+        0xFF00FC00.toInt(),
+        0xFF009393.toInt(),
+        0xFF00FFFF.toInt(),
+        0xFF0000FC.toInt(),
+        0xFFFF00FF.toInt(),
+        0xFF7F7F7F.toInt(),
+        0xFFD2D2D2.toInt(),
+    )
+
+private fun mircColor(index: Int): Color? = MIRC_COLORS_16.getOrNull(index)?.let(::Color)
+
+internal data class MircRun(
+    val text: String,
+    val style: SpanStyle,
+)
+
+internal fun mircFormattedText(text: String): AnnotatedString {
+    if (text.none { it.code in 0x01..0x1F }) return AnnotatedString(text)
+    return buildAnnotatedString {
+        for (run in parseMircFormatting(text)) withStyle(run.style) { append(run.text) }
+    }
+}
+
+/**
+ * Splits raw IRC text on mIRC formatting control codes (bold/italic/underline/strikethrough/
+ * monospace/reverse/color/reset) into styled runs with the codes themselves stripped. A run
+ * carries the SpanStyle that was active when its text was appended; unset properties are left
+ * null/Unspecified so the caller's own base style shows through on merge.
+ */
+internal fun parseMircFormatting(text: String): List<MircRun> {
+    if (text.none { it.code in 0x01..0x1F }) return listOf(MircRun(text, SpanStyle()))
+
+    val runs = mutableListOf<MircRun>()
+    val sb = StringBuilder()
+    var bold = false
+    var italic = false
+    var underline = false
+    var strikethrough = false
+    var monospace = false
+    var reversed = false
+    var fg: Int? = null
+    var bg: Int? = null
+
+    fun currentStyle(): SpanStyle {
+        val effectiveFg = if (reversed) bg else fg
+        val effectiveBg = if (reversed) fg else bg
+        val decorations =
+            buildList {
+                if (underline) add(TextDecoration.Underline)
+                if (strikethrough) add(TextDecoration.LineThrough)
+            }
+        return SpanStyle(
+            color = effectiveFg?.let { mircColor(it) } ?: Color.Unspecified,
+            background = effectiveBg?.let { mircColor(it) } ?: Color.Unspecified,
+            fontWeight = if (bold) FontWeight.Bold else null,
+            fontStyle = if (italic) FontStyle.Italic else null,
+            textDecoration = if (decorations.isEmpty()) null else TextDecoration.combine(decorations),
+            fontFamily = if (monospace) FontFamily.Monospace else null,
+        )
+    }
+
+    fun flush() {
+        if (sb.isNotEmpty()) {
+            runs += MircRun(sb.toString(), currentStyle())
+            sb.clear()
+        }
+    }
+
+    fun readDigits(
+        source: String,
+        from: Int,
+        maxDigits: Int,
+    ): Pair<Int?, Int> {
+        var i = from
+        while (i < source.length && source[i].isDigit() && i - from < maxDigits) i++
+        return if (i > from) source.substring(from, i).toInt() to i else null to from
+    }
+
+    var i = 0
+    while (i < text.length) {
+        when (text[i]) {
+            CH_BOLD -> {
+                flush()
+                bold = !bold
+                i++
+            }
+
+            CH_ITALIC -> {
+                flush()
+                italic = !italic
+                i++
+            }
+
+            CH_UNDERLINE -> {
+                flush()
+                underline = !underline
+                i++
+            }
+
+            CH_STRIKETHROUGH -> {
+                flush()
+                strikethrough = !strikethrough
+                i++
+            }
+
+            CH_MONOSPACE -> {
+                flush()
+                monospace = !monospace
+                i++
+            }
+
+            CH_REVERSE -> {
+                flush()
+                reversed = !reversed
+                i++
+            }
+
+            CH_RESET -> {
+                flush()
+                bold = false
+                italic = false
+                underline = false
+                strikethrough = false
+                monospace = false
+                reversed = false
+                fg = null
+                bg = null
+                i++
+            }
+
+            CH_COLOR -> {
+                flush()
+                i++
+                val (newFg, afterFg) = readDigits(text, i, 2)
+                i = afterFg
+                var newBg: Int? = null
+                if (i < text.length && text[i] == ',') {
+                    val (bgVal, afterBg) = readDigits(text, i + 1, 2)
+                    if (bgVal != null) {
+                        newBg = bgVal
+                        i = afterBg
+                    }
+                }
+                if (newFg == null && newBg == null) {
+                    fg = null
+                    bg = null
+                } else {
+                    if (newFg != null) fg = newFg
+                    if (newBg != null) bg = newBg
+                }
+            }
+
+            else -> {
+                sb.append(text[i])
+                i++
+            }
+        }
+    }
+    flush()
+    return runs
+}

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/NetworkSettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -187,6 +188,7 @@ fun NetworkSettingsContent(
                         .fillMaxWidth()
                         .widthIn(max = 720.dp)
                         .verticalScroll(rememberScrollState())
+                        .imePadding()
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -136,6 +137,7 @@ fun AddNetworkContent(
                         .fillMaxWidth()
                         .widthIn(max = 720.dp)
                         .verticalScroll(rememberScrollState())
+                        .imePadding()
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/components/MessageBubbleTextTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/components/MessageBubbleTextTest.kt
@@ -2,6 +2,8 @@ package io.github.trevarj.motd.ui.components
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontSynthesis
@@ -108,6 +110,31 @@ class MessageBubbleTextTest {
                 .filter { it.item.color == Color.Red }
                 .map { body.text.substring(it.start, it.end) }
         assertEquals(listOf("@bob"), redRuns)
+    }
+
+    @Test
+    fun mirc_color_overrides_plain_body_color() {
+        val body =
+            buildAnnotatedString {
+                appendRichText(
+                    text = "\u000304red",
+                    plainStyle = SpanStyle(color = Color.Green),
+                    linkStyle = SpanStyle(color = Color.Blue),
+                    codeStyle = SpanStyle(fontFamily = FontFamily.Monospace),
+                )
+            }
+
+        assertEquals("red", body.text)
+        assertTrue(body.spanStyles.any { it.item.color == Color.Red })
+    }
+
+    @Test
+    fun mirc_preview_leaves_urls_and_backticks_inert() {
+        val body = mircFormattedText("\u000304visit https://example.com and `code`")
+
+        assertEquals("visit https://example.com and `code`", body.text)
+        assertTrue(body.spanStyles.any { it.item.color == Color.Red })
+        assertTrue(!body.hasLinkAnnotations(0, body.length))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a mIRC control-code parser (`MircFormatting.kt`) that splits message text on bold/italic/underline/strikethrough/monospace/reverse/color/reset codes into styled runs, stripping the raw control bytes.
- Wire it into `appendRichText` in `MessageBubble.kt` (before code-span/URL/mention handling, since formatting can wrap around any of those) so chat messages render actual colors/styles instead of the raw digits (e.g. `\x0304Word` used to literally show as `04Word`).
- Extend channel topics (`ChannelInfoScreen.kt`) to go through the same rendering pipeline, since topics commonly carry color/bold formatting too.
- Scope note: only the original 16-color mIRC palette (codes 0-15) is mapped to actual colors. Codes 16-98 (HexChat's later "256-color" extension) are still parsed and stripped so the digits never leak into the message body, but aren't mapped to a color — that extended palette isn't part of the original mIRC spec and isn't consistently implemented/documented across clients, so I didn't want to hardcode a possibly-wrong RGB table.

## Test plan
- Built debug APK, connected to a network sending colored/bold text (e.g. topic banners, bot output), confirmed colors/bold/underline/etc render correctly instead of showing raw control-code digits.
- Confirmed a channel topic with color codes now renders formatted in the Channel Info screen.
- Confirmed plain messages (no formatting) and messages with URLs/mentions/code spans still render as before.