### PR TITLE
Let the add-network form name the network up front

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -76,6 +77,7 @@ fun AddNetworkScreen(
         onSetKind = viewModel::setKind,
         onSetBouncerKind = viewModel::setBouncerKind,
         onSelectPreset = viewModel::selectPreset,
+        onDisplayNameChange = viewModel::editDisplayName,
         onServerChange = viewModel::editServer,
         onAuthChange = viewModel::editAuth,
         onSojuLoginChange = viewModel::editSojuLogin,
@@ -98,6 +100,7 @@ fun AddNetworkContent(
     onSetKind: (ConnectionChoice) -> Unit,
     onSetBouncerKind: (BouncerKind) -> Unit,
     onSelectPreset: (NetworkPresetId) -> Unit,
+    onDisplayNameChange: (String) -> Unit,
     onServerChange: (ServerForm) -> Unit,
     onAuthChange: (AuthForm) -> Unit,
     onSojuLoginChange: (SojuLoginForm) -> Unit,
@@ -169,6 +172,24 @@ fun AddNetworkContent(
                     }
                 }
                 SettingsGroup(title = stringResource(R.string.add_network_details_section)) {
+                    // ZNC already collects its own per-bouncer network name (zncLogin.network,
+                    // required for auth); this field only needs to exist for DIRECT/soju, which
+                    // otherwise fall back to the preset name or bare host until edited later.
+                    if (!state.isZnc) {
+                        OutlinedTextField(
+                            value = state.displayName,
+                            onValueChange = onDisplayNameChange,
+                            label = { Text(stringResource(R.string.network_settings_display_name)) },
+                            placeholder = {
+                                Text(
+                                    networkPreset(state.presetId)?.displayName
+                                        ?: state.server.host.ifBlank { stringResource(R.string.add_network_kind_network) },
+                                )
+                            },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("add_network_display_name"),
+                        )
+                    }
                     // Ease the height between the two form variants; the branch swap itself (and
                     // its field state reset) is unchanged from today.
                     Box(Modifier.animateContentSize(animationSpec = MotdMotion.contentSize)) {
@@ -401,6 +422,7 @@ private fun AddNetworkFormPreview() {
             onSetKind = {},
             onSetBouncerKind = {},
             onSelectPreset = {},
+            onDisplayNameChange = {},
             onServerChange = {},
             onAuthChange = {},
             onSojuLoginChange = {},
@@ -431,6 +453,7 @@ private fun AddNetworkFailedPreview() {
             onSetKind = {},
             onSetBouncerKind = {},
             onSelectPreset = {},
+            onDisplayNameChange = {},
             onServerChange = {},
             onAuthChange = {},
             onSojuLoginChange = {},

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
@@ -32,6 +32,10 @@ enum class AddNetworkPhase { FORM, TESTING, FAILED }
 data class AddNetworkUiState(
     val kind: ConnectionChoice = ConnectionChoice.NETWORK,
     val bouncerKind: BouncerKind = BouncerKind.SOJU,
+    // ZNC already collects its own per-bouncer network name via zncLogin.network; this only
+    // covers the DIRECT and soju-root cases, where nothing today lets the user name the row
+    // before it's created.
+    val displayName: String = "",
     val server: ServerForm = ServerForm(),
     val auth: AuthForm = AuthForm(),
     val sojuLogin: SojuLoginForm = SojuLoginForm(),
@@ -142,6 +146,10 @@ class AddNetworkViewModel
                 )
         }
 
+        fun editDisplayName(name: String) {
+            _state.value = _state.value.copy(displayName = name)
+        }
+
         fun editAuth(auth: AuthForm) {
             _state.value = _state.value.copy(auth = auth)
         }
@@ -185,6 +193,7 @@ class AddNetworkViewModel
                             name =
                                 when {
                                     s.isZnc -> s.zncLogin.network.trim()
+                                    s.displayName.isNotBlank() -> s.displayName.trim()
                                     else -> networkPreset(s.presetId)?.displayName ?: s.server.host
                                 },
                         )

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/settings/AddNetworkViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/settings/AddNetworkViewModelTest.kt
@@ -194,6 +194,35 @@ class AddNetworkViewModelTest {
         }
 
     @Test
+    fun direct_network_uses_entered_display_name_over_host() =
+        runTest {
+            val repo = FakeNetworkRepository()
+            val vm = vm(repo, FakeConnectionManager())
+            vm.fillValidDirect()
+            vm.editDisplayName("  My Home Network  ")
+
+            vm.submit(onOpenBouncerNetworks = { error("not a bouncer") }, onDone = {})
+            runCurrent()
+
+            val id = vm.state.value.networkId!!
+            assertEquals("My Home Network", repo.networks.getValue(id).name)
+        }
+
+    @Test
+    fun direct_network_falls_back_to_host_when_display_name_is_blank() =
+        runTest {
+            val repo = FakeNetworkRepository()
+            val vm = vm(repo, FakeConnectionManager())
+            vm.fillValidDirect()
+
+            vm.submit(onOpenBouncerNetworks = { error("not a bouncer") }, onDone = {})
+            runCurrent()
+
+            val id = vm.state.value.networkId!!
+            assertEquals("irc.libera.chat", repo.networks.getValue(id).name)
+        }
+
+    @Test
     fun soju_missing_password_or_nick_is_not_submittable() =
         runTest {
             val vm = vm(FakeNetworkRepository(), FakeConnectionManager())


### PR DESCRIPTION
## Summary
- A DIRECT or soju network could previously only be renamed after creation, in NetworkSettings — until then it fell back to the preset name or bare host.
- Adds a "Network name" field to the add-network form for those two kinds. ZNC is untouched, since it already collects a required per-bouncer network name (`zncLogin.network`) that serves the same purpose.
- Blank input keeps today's fallback behavior (preset name, else host) so existing flows are unaffected.

## Test plan
- [x] `AddNetworkViewModelTest`: added `direct_network_uses_entered_display_name_over_host` and `direct_network_falls_back_to_host_when_display_name_is_blank`; full suite passes (16/16).
- [x] `./gradlew assembleDebug` succeeds.
- [x] Manually verified on-device: entering a name in Add Network and submitting uses it as the network's display name.