### PR TITLE
fix(chatlist): strip mIRC formatting codes from last-message preview

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
@@ -59,6 +59,7 @@ import io.github.trevarj.motd.audio.parseAudioAttachments
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.ChatListRow
 import io.github.trevarj.motd.data.prefs.TimeFormat
+import io.github.trevarj.motd.irc.format.plainIrcText
 import io.github.trevarj.motd.service.PresenceState
 import io.github.trevarj.motd.ui.components.AdvertisedActivityDot
 import io.github.trevarj.motd.ui.components.Avatar
@@ -68,7 +69,6 @@ import io.github.trevarj.motd.ui.components.MutedActivityBadge
 import io.github.trevarj.motd.ui.components.NetworkChip
 import io.github.trevarj.motd.ui.components.UnreadBadge
 import io.github.trevarj.motd.ui.components.avatarsHidden
-import io.github.trevarj.motd.ui.components.mircFormattedText
 import io.github.trevarj.motd.ui.components.rememberMessageTimeFormatter
 import io.github.trevarj.motd.ui.components.resolveIs24Hour
 import io.github.trevarj.motd.ui.theme.LocalMotdSemanticColors
@@ -157,6 +157,13 @@ internal sealed interface ChatListMessagePreview {
         val durationMs: Long?,
     ) : ChatListMessagePreview
 }
+
+/**
+ * The preview line renders as plain text only: no color/bold/italic spans, just mIRC control codes
+ * stripped (a color prefix like `\x0302` must not leak into the row as literal digits).
+ */
+internal fun chatListPreviewText(text: String): androidx.compose.ui.text.AnnotatedString =
+    androidx.compose.ui.text.AnnotatedString(plainIrcText(text))
 
 internal fun chatListMessagePreview(text: String?): ChatListMessagePreview {
     val value = text.orEmpty()
@@ -411,7 +418,7 @@ fun ChatListRowItem(
                     text =
                         when (preview) {
                             is ChatListMessagePreview.Text -> {
-                                mircFormattedText(preview.value)
+                                chatListPreviewText(preview.value)
                             }
 
                             is ChatListMessagePreview.Voice -> {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
@@ -68,6 +68,7 @@ import io.github.trevarj.motd.ui.components.MutedActivityBadge
 import io.github.trevarj.motd.ui.components.NetworkChip
 import io.github.trevarj.motd.ui.components.UnreadBadge
 import io.github.trevarj.motd.ui.components.avatarsHidden
+import io.github.trevarj.motd.ui.components.mircFormattedText
 import io.github.trevarj.motd.ui.components.rememberMessageTimeFormatter
 import io.github.trevarj.motd.ui.components.resolveIs24Hour
 import io.github.trevarj.motd.ui.theme.LocalMotdSemanticColors
@@ -410,8 +411,7 @@ fun ChatListRowItem(
                     text =
                         when (preview) {
                             is ChatListMessagePreview.Text -> {
-                                androidx.compose.ui.text
-                                    .AnnotatedString(preview.value)
+                                mircFormattedText(preview.value)
                             }
 
                             is ChatListMessagePreview.Voice -> {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -162,8 +163,7 @@ internal sealed interface ChatListMessagePreview {
  * The preview line renders as plain text only: no color/bold/italic spans, just mIRC control codes
  * stripped (a color prefix like `\x0302` must not leak into the row as literal digits).
  */
-internal fun chatListPreviewText(text: String): androidx.compose.ui.text.AnnotatedString =
-    androidx.compose.ui.text.AnnotatedString(plainIrcText(text))
+internal fun chatListPreviewText(text: String): AnnotatedString = AnnotatedString(plainIrcText(text))
 
 internal fun chatListMessagePreview(text: String?): ChatListMessagePreview {
     val value = text.orEmpty()
@@ -422,7 +422,7 @@ fun ChatListRowItem(
                             }
 
                             is ChatListMessagePreview.Voice -> {
-                                androidx.compose.ui.text.AnnotatedString(
+                                AnnotatedString(
                                     buildString {
                                         append(stringResource(R.string.chatlist_voice_message))
                                         preview.durationMs?.let { append(" · ${formatAudioDuration(it)}") }

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMessagePreviewTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMessagePreviewTest.kt
@@ -7,6 +7,15 @@ import org.junit.Test
 
 class ChatListMessagePreviewTest {
     @Test
+    fun `preview strips mIRC control codes without adding formatting spans`() {
+        val colorCode = 0x03.toChar()
+        val raw = "[" + colorCode + "02OneFM" + colorCode + "] DJ: Auto DJ"
+        val preview = chatListPreviewText(raw)
+        assertEquals("[OneFM] DJ: Auto DJ", preview.text)
+        assertEquals(0, preview.spanStyles.size)
+    }
+
+    @Test
     fun `voice fallback becomes a compact voice preview`() {
         assertEquals(
             ChatListMessagePreview.Voice(durationMs = 14_000),


### PR DESCRIPTION
## Summary
- The chat-list last-message preview rendered raw message text via a plain `AnnotatedString`, so an mIRC color prefix (e.g. `\x0302`) showed up as a literal `02` before the text — e.g. `02OneFM` instead of `OneFM`.
- Route the preview through `mircFormattedText` (already used elsewhere for rich text) so control codes are parsed and stripped.
- Colors are intentionally not rendered here — the last-message preview stays plain text by design, matching how it looked before formatted bots started sending colored notices.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Verified on-device: RadioBot's colored `[OneFM] ...` notice now shows as plain `[OneFM] ...` with no stray digits.