### PR TITLE
fix(link-preview): decode numeric and common named HTML entities

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/data/repo/LinkPreviewRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/repo/LinkPreviewRepositoryImpl.kt
@@ -598,7 +598,23 @@ class LinkPreviewRepositoryImpl
                     ?.takeIf { it.isNotEmpty() }
             }
 
-            // Minimal HTML entity decode for the handful common in OG text.
+            private val NUMERIC_ENTITY = Regex("&#(x[0-9a-fA-F]+|[0-9]+);")
+            private val NAMED_ENTITIES =
+                mapOf(
+                    "nbsp" to " ",
+                    "ndash" to "–",
+                    "mdash" to "—",
+                    "hellip" to "…",
+                    "rsquo" to "’",
+                    "lsquo" to "‘",
+                    "rdquo" to "”",
+                    "ldquo" to "“",
+                )
+
+            // HTML entity decode for OG/title text: the handful of literal entities common in hand-
+            // written markup, plus numeric character references (decimal and hex) that CMS-rendered
+            // pages routinely emit for punctuation like en/em dashes. sanitizeText still runs after
+            // this and strips any CONTROL/FORMAT code points a malicious numeric reference decodes to.
             private fun decodeEntities(s: String): String =
                 s
                     .replace("&amp;", "&")
@@ -607,6 +623,25 @@ class LinkPreviewRepositoryImpl
                     .replace("&quot;", "\"")
                     .replace("&#39;", "'")
                     .replace("&#x27;", "'")
+                    .let { withNamed ->
+                        NAMED_ENTITIES.entries.fold(withNamed) { acc, (name, value) ->
+                            acc.replace("&$name;", value)
+                        }
+                    }.let { withNumeric ->
+                        NUMERIC_ENTITY.replace(withNumeric) { match ->
+                            val ref = match.groupValues[1]
+                            val codePoint =
+                                if (ref.startsWith("x", ignoreCase = true)) {
+                                    ref.drop(1).toIntOrNull(16)
+                                } else {
+                                    ref.toIntOrNull()
+                                }
+                            codePoint
+                                ?.takeIf(Character::isValidCodePoint)
+                                ?.let { String(Character.toChars(it)) }
+                                ?: match.value
+                        }
+                    }
 
             internal fun isPopularVideoUrl(url: String): Boolean =
                 runCatching {

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/repo/LinkPreviewRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/repo/LinkPreviewRepositoryImpl.kt
@@ -598,9 +598,13 @@ class LinkPreviewRepositoryImpl
                     ?.takeIf { it.isNotEmpty() }
             }
 
-            private val NUMERIC_ENTITY = Regex("&#(x[0-9a-fA-F]+|[0-9]+);")
+            private val HTML_ENTITY = Regex("&(?:#(?:[xX][0-9a-fA-F]+|[0-9]+)|[a-z]+);")
             private val NAMED_ENTITIES =
                 mapOf(
+                    "amp" to "&",
+                    "lt" to "<",
+                    "gt" to ">",
+                    "quot" to "\"",
                     "nbsp" to " ",
                     "ndash" to "–",
                     "mdash" to "—",
@@ -611,37 +615,26 @@ class LinkPreviewRepositoryImpl
                     "ldquo" to "“",
                 )
 
-            // HTML entity decode for OG/title text: the handful of literal entities common in hand-
-            // written markup, plus numeric character references (decimal and hex) that CMS-rendered
-            // pages routinely emit for punctuation like en/em dashes. sanitizeText still runs after
-            // this and strips any CONTROL/FORMAT code points a malicious numeric reference decodes to.
+            // Decode one entity layer only; leave unknown, malformed, and surrogate references intact.
             private fun decodeEntities(s: String): String =
-                s
-                    .replace("&amp;", "&")
-                    .replace("&lt;", "<")
-                    .replace("&gt;", ">")
-                    .replace("&quot;", "\"")
-                    .replace("&#39;", "'")
-                    .replace("&#x27;", "'")
-                    .let { withNamed ->
-                        NAMED_ENTITIES.entries.fold(withNamed) { acc, (name, value) ->
-                            acc.replace("&$name;", value)
-                        }
-                    }.let { withNumeric ->
-                        NUMERIC_ENTITY.replace(withNumeric) { match ->
-                            val ref = match.groupValues[1]
-                            val codePoint =
-                                if (ref.startsWith("x", ignoreCase = true)) {
-                                    ref.drop(1).toIntOrNull(16)
-                                } else {
-                                    ref.toIntOrNull()
-                                }
-                            codePoint
-                                ?.takeIf(Character::isValidCodePoint)
-                                ?.let { String(Character.toChars(it)) }
-                                ?: match.value
-                        }
+                HTML_ENTITY.replace(s) { match ->
+                    val ref = match.value.substring(1, match.value.lastIndex)
+                    if (!ref.startsWith('#')) {
+                        NAMED_ENTITIES[ref] ?: match.value
+                    } else {
+                        val number = ref.drop(1)
+                        val codePoint =
+                            if (number.startsWith("x", ignoreCase = true)) {
+                                number.drop(1).toIntOrNull(16)
+                            } else {
+                                number.toIntOrNull()
+                            }
+                        codePoint
+                            ?.takeIf { Character.isValidCodePoint(it) && it !in 0xD800..0xDFFF }
+                            ?.let { String(Character.toChars(it)) }
+                            ?: match.value
                     }
+                }
 
             internal fun isPopularVideoUrl(url: String): Boolean =
                 runCatching {

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/repo/OgParserTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/repo/OgParserTest.kt
@@ -56,6 +56,14 @@ class OgParserTest {
     }
 
     @Test
+    fun decodesNumericAndNamedEntities() {
+        val html =
+            """<meta property="og:title" content="Tor is back &#8211; PTirc &mdash; &#x2026;">"""
+        val p = LinkPreviewRepositoryImpl.parseOgTags(url, html)!!
+        assertEquals("Tor is back – PTirc — …", p.title)
+    }
+
+    @Test
     fun noExtractableTags_returnsNull() {
         val html = "<html><body>no metadata at all</body></html>"
         assertNull(LinkPreviewRepositoryImpl.parseOgTags(url, html))

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/repo/OgParserTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/repo/OgParserTest.kt
@@ -64,6 +64,14 @@ class OgParserTest {
     }
 
     @Test
+    fun decodesOneEntityLayerAndPreservesSurrogates() {
+        val html =
+            """<meta property="og:title" content="&amp;#8211; &amp;amp;#8211; &#X2026; &#55296;">"""
+        val p = LinkPreviewRepositoryImpl.parseOgTags(url, html)!!
+        assertEquals("&#8211; &amp;#8211; … &#55296;", p.title)
+    }
+
+    @Test
     fun noExtractableTags_returnsNull() {
         val html = "<html><body>no metadata at all</body></html>"
         assertNull(LinkPreviewRepositoryImpl.parseOgTags(url, html))


### PR DESCRIPTION
## Summary
- `decodeEntities` in the OG/title parser only handled a handful of literal entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, `&#x27;`), so CMS-rendered `og:title` values using numeric character references leaked through as literal text — e.g. `Tor is back &#8211; PTirc` instead of `Tor is back – PTirc`.
- Added decimal (`&#8211;`) and hex (`&#x2026;`) numeric entity decoding, plus a small set of common named entities (`nbsp`, `ndash`, `mdash`, `hellip`, smart quotes).
- `sanitizeText` still runs after decoding and strips any CONTROL/FORMAT code points a hostile numeric reference could decode to, so this doesn't weaken the existing spoofing guard.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.data.repo.OgParserTest` (added `decodesNumericAndNamedEntities`)
- [x] Verified on-device: the `ptirc.org` link-preview card title now renders `Tor de regresso/Tor is back – PTirc` instead of the literal `&#8211;`.