### PR TITLE
feat(chatlist): add mark-as-read to the multi-select toolbar

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Mail
 import androidx.compose.material.icons.outlined.Notifications
@@ -242,6 +243,7 @@ fun ChatListScreen(
         onScanInvite = onScanInvite,
         onOpenChannelList = onOpenChannelList,
         onMarkAllRead = viewModel::markCurrentScopeRead,
+        onMarkSelectedRead = viewModel::markSelectedRead,
         onMoveNetwork = viewModel::moveNetwork,
         onCommitNetworkOrder = viewModel::commitNetworkOrder,
         selectedBufferId = selectedBufferId,
@@ -314,6 +316,7 @@ fun ChatListContent(
     onScanInvite: () -> Unit = {},
     onOpenChannelList: (Long) -> Unit = {},
     onMarkAllRead: () -> Unit = {},
+    onMarkSelectedRead: (Collection<Long>) -> Unit = {},
     // Manual drawer order (see DrawerReorder.kt); defaulted so previews and tests stay terse.
     onMoveNetwork: (Long, Int) -> Unit = { _, _ -> },
     onCommitNetworkOrder: (List<Long>) -> Unit = {},
@@ -535,6 +538,16 @@ fun ChatListContent(
                                             },
                                             modifier = Modifier.testTag("chatlist_selection_mute"),
                                         ) { Icon(if (muteTarget) Icons.Outlined.NotificationsOff else Icons.Outlined.Notifications, stringResource(if (muteTarget) R.string.chatlist_mute else R.string.chatlist_unmute)) }
+                                        IconButton(
+                                            onClick = {
+                                                // Explicit per-selection action: unlike mark-all, this
+                                                // includes muted rows on purpose (hand-picking one is
+                                                // opting it in).
+                                                onMarkSelectedRead(selectedRows.map(ChatListRow::bufferId))
+                                                selectedIds = emptyList()
+                                            },
+                                            modifier = Modifier.testTag("chatlist_selection_mark_read"),
+                                        ) { Icon(Icons.Outlined.DoneAll, stringResource(R.string.chatlist_mark_read)) }
                                         IconButton(
                                             onClick = {
                                                 setArchivedWithReveal(selectedRows.map(ChatListRow::bufferId), !archiveMode)

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -47,6 +48,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Delete
@@ -66,6 +68,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
@@ -129,10 +133,12 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.view.HapticFeedbackConstantsCompat
 import androidx.core.view.ViewCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -440,7 +446,17 @@ fun ChatListContent(
                         ) { mode ->
                             when (mode) {
                                 ChatListTopBarMode.SELECTION -> {
-                                    Text(pluralStringResource(R.plurals.chatlist_selected_count, lastSelectedRows.size, lastSelectedRows.size))
+                                    // Never wrap: a growing action row must shrink this font instead
+                                    // of pushing the count to multiple lines and blowing out the bar's
+                                    // height. Ellipsis is only the last-resort floor once even the
+                                    // smallest step can't fit (e.g. a huge selected count on a tiny
+                                    // screen).
+                                    Text(
+                                        pluralStringResource(R.plurals.chatlist_selected_count, lastSelectedRows.size, lastSelectedRows.size),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        autoSize = TextAutoSize.StepBased(minFontSize = 14.sp, maxFontSize = 22.sp),
+                                    )
                                 }
 
                                 ChatListTopBarMode.INVITATIONS -> {
@@ -524,25 +540,14 @@ fun ChatListContent(
                                         // still apply to the live selection.
                                         val pinTarget = aggregateToggleTarget(lastSelectedRows) { it.pinned }
                                         val muteTarget = aggregateToggleTarget(lastSelectedRows) { it.muted }
+                                        var overflowOpen by remember { mutableStateOf(false) }
+                                        // Only the three most-reached-for actions stay inline; pin and
+                                        // archive move behind "more" so a growing action set never
+                                        // starves the title (the autoSize/ellipsis fallback above is
+                                        // the last resort, not the primary fix) or forces icons to
+                                        // shrink/wrap on narrower phones.
                                         IconButton(
                                             onClick = {
-                                                onSetPinned(selectedRows.map(ChatListRow::bufferId), pinTarget)
-                                                selectedIds = emptyList()
-                                            },
-                                            modifier = Modifier.testTag("chatlist_selection_pin"),
-                                        ) { Icon(Icons.Filled.PushPin, stringResource(if (pinTarget) R.string.chatlist_pin else R.string.chatlist_unpin)) }
-                                        IconButton(
-                                            onClick = {
-                                                onSetMuted(selectedRows.map(ChatListRow::bufferId), muteTarget)
-                                                selectedIds = emptyList()
-                                            },
-                                            modifier = Modifier.testTag("chatlist_selection_mute"),
-                                        ) { Icon(if (muteTarget) Icons.Outlined.NotificationsOff else Icons.Outlined.Notifications, stringResource(if (muteTarget) R.string.chatlist_mute else R.string.chatlist_unmute)) }
-                                        IconButton(
-                                            onClick = {
-                                                // Explicit per-selection action: unlike mark-all, this
-                                                // includes muted rows on purpose (hand-picking one is
-                                                // opting it in).
                                                 onMarkSelectedRead(selectedRows.map(ChatListRow::bufferId))
                                                 selectedIds = emptyList()
                                             },
@@ -550,13 +555,49 @@ fun ChatListContent(
                                         ) { Icon(Icons.Outlined.DoneAll, stringResource(R.string.chatlist_mark_read)) }
                                         IconButton(
                                             onClick = {
-                                                setArchivedWithReveal(selectedRows.map(ChatListRow::bufferId), !archiveMode)
+                                                onSetMuted(selectedRows.map(ChatListRow::bufferId), muteTarget)
                                                 selectedIds = emptyList()
                                             },
-                                            modifier = Modifier.testTag("chatlist_selection_archive"),
-                                        ) { Icon(archiveActionIcon(archiveMode), stringResource(if (archiveMode) R.string.chatlist_unarchive else R.string.chatlist_archive)) }
+                                            modifier = Modifier.testTag("chatlist_selection_mute"),
+                                        ) { Icon(if (muteTarget) Icons.Outlined.NotificationsOff else Icons.Outlined.Notifications, stringResource(if (muteTarget) R.string.chatlist_mute else R.string.chatlist_unmute)) }
                                         IconButton(onClick = { confirmRemoval = true }, modifier = Modifier.testTag("chatlist_selection_remove")) {
                                             Icon(Icons.Outlined.Delete, stringResource(R.string.chatlist_remove))
+                                        }
+                                        Box {
+                                            IconButton(
+                                                onClick = { overflowOpen = true },
+                                                modifier = Modifier.testTag("chatlist_selection_more"),
+                                            ) {
+                                                Icon(Icons.Filled.MoreVert, stringResource(R.string.chatlist_more_actions))
+                                            }
+                                            DropdownMenu(expanded = overflowOpen, onDismissRequest = { overflowOpen = false }) {
+                                                DropdownMenuItem(
+                                                    text = { Text(stringResource(if (pinTarget) R.string.chatlist_pin else R.string.chatlist_unpin)) },
+                                                    leadingIcon = { Icon(Icons.Filled.PushPin, contentDescription = null) },
+                                                    modifier = Modifier.testTag("chatlist_selection_pin"),
+                                                    onClick = {
+                                                        onSetPinned(selectedRows.map(ChatListRow::bufferId), pinTarget)
+                                                        selectedIds = emptyList()
+                                                        overflowOpen = false
+                                                    },
+                                                )
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Text(
+                                                            stringResource(
+                                                                if (archiveMode) R.string.chatlist_unarchive else R.string.chatlist_archive,
+                                                            ),
+                                                        )
+                                                    },
+                                                    leadingIcon = { Icon(archiveActionIcon(archiveMode), contentDescription = null) },
+                                                    modifier = Modifier.testTag("chatlist_selection_archive"),
+                                                    onClick = {
+                                                        setArchivedWithReveal(selectedRows.map(ChatListRow::bufferId), !archiveMode)
+                                                        selectedIds = emptyList()
+                                                        overflowOpen = false
+                                                    },
+                                                )
+                                            }
                                         }
                                     }
 

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListViewModel.kt
@@ -522,6 +522,16 @@ class ChatListViewModel
             viewModelScope.launch { markChatsRead(bufferIds, readMarkerRepository, connectionManager) }
         }
 
+        /**
+         * Mark an explicit selection read, muted rows included: mark-all deliberately skips muted
+         * chats, but a user hand-selecting one is opting it in on purpose.
+         */
+        fun markSelectedRead(bufferIds: Collection<Long>) {
+            val ids = bufferIds.toList().distinct()
+            if (ids.isEmpty()) return
+            viewModelScope.launch { markChatsRead(ids, readMarkerRepository, connectionManager) }
+        }
+
         private fun setSelection(networkId: Long?) {
             selection.value = networkId
             savedStateHandle[KEY_SELECTED] = networkId

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1167,6 +1167,7 @@
     <string name="chatlist_mute">Mute</string>
     <string name="chatlist_unmute">Unmute</string>
     <string name="chatlist_mark_read">Mark as read</string>
+    <string name="chatlist_more_actions">More actions</string>
     <string name="chatlist_archive">Archive</string>
     <string name="chatlist_unarchive">Unarchive</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1166,6 +1166,7 @@
     <string name="chatlist_unpin">Unpin</string>
     <string name="chatlist_mute">Mute</string>
     <string name="chatlist_unmute">Unmute</string>
+    <string name="chatlist_mark_read">Mark as read</string>
     <string name="chatlist_archive">Archive</string>
     <string name="chatlist_unarchive">Unarchive</string>
 

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMarkSelectedReadTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMarkSelectedReadTest.kt
@@ -1,0 +1,313 @@
+package io.github.trevarj.motd.ui.chatlist
+
+import androidx.lifecycle.SavedStateHandle
+import io.github.trevarj.motd.data.db.BufferEntity
+import io.github.trevarj.motd.data.db.BufferType
+import io.github.trevarj.motd.data.db.ChatListRow
+import io.github.trevarj.motd.data.db.MemberEntity
+import io.github.trevarj.motd.data.db.MuteBacklogSuppression
+import io.github.trevarj.motd.data.db.NetworkEntity
+import io.github.trevarj.motd.data.db.TimelineAnchor
+import io.github.trevarj.motd.data.prefs.AvatarStyle
+import io.github.trevarj.motd.data.prefs.FoolsMode
+import io.github.trevarj.motd.data.prefs.LayoutDensity
+import io.github.trevarj.motd.data.prefs.NickColorPalette
+import io.github.trevarj.motd.data.prefs.OnboardingPrefs
+import io.github.trevarj.motd.data.prefs.PresenceMode
+import io.github.trevarj.motd.data.prefs.Settings
+import io.github.trevarj.motd.data.prefs.SettingsRepository
+import io.github.trevarj.motd.data.prefs.ThemeMode
+import io.github.trevarj.motd.data.repo.BufferRepository
+import io.github.trevarj.motd.data.repo.NetworkRepository
+import io.github.trevarj.motd.irc.client.IrcClient
+import io.github.trevarj.motd.irc.event.IrcClientState
+import io.github.trevarj.motd.service.AppVisibility
+import io.github.trevarj.motd.service.BufferReadMarker
+import io.github.trevarj.motd.service.ChannelCloseCoordinator
+import io.github.trevarj.motd.service.DeliveryMode
+import io.github.trevarj.motd.service.HistoryResyncController
+import io.github.trevarj.motd.service.HistoryResyncState
+import io.github.trevarj.motd.service.HistorySyncStatus
+import io.github.trevarj.motd.service.ReadMarkerSnapshotter
+import io.github.trevarj.motd.service.unreadBufferIds
+import io.github.trevarj.motd.testing.NoopConnectionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * markSelectedRead is the explicit per-selection counterpart to markCurrentScopeRead: unlike the
+ * mark-all sweep, it must reach a muted buffer, since the user hand-picked it on purpose.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatListMarkSelectedReadTest {
+    private class FakeBufferRepository(
+        private val rows: Flow<List<ChatListRow>>,
+    ) : BufferRepository {
+        override fun observeChatList(): Flow<List<ChatListRow>> = rows
+
+        override fun observeBuffer(id: Long): Flow<BufferEntity?> = flowOf(null)
+
+        override fun observeMembers(bufferId: Long): Flow<List<MemberEntity>> = flowOf(emptyList())
+
+        override suspend fun setPinned(
+            id: Long,
+            pinned: Boolean,
+        ) = Unit
+
+        override suspend fun setMuted(
+            id: Long,
+            muted: Boolean,
+        ): MuteBacklogSuppression? = null
+
+        override suspend fun setLayoutDensityOverride(
+            id: Long,
+            layout: LayoutDensity?,
+        ): Boolean = true
+
+        override suspend fun setPresenceModeOverride(
+            id: Long,
+            mode: PresenceMode?,
+        ): Boolean = true
+
+        override suspend fun deleteBuffer(id: Long) = Unit
+    }
+
+    private class FakeNetworkRepository : NetworkRepository {
+        override fun observeNetworks(): Flow<List<NetworkEntity>> = flowOf(emptyList())
+
+        override suspend fun addNetwork(n: NetworkEntity): Long = 0
+
+        override suspend fun updateNetwork(n: NetworkEntity) = Unit
+
+        override suspend fun deleteNetwork(id: Long) = Unit
+
+        override suspend fun reorderNetworks(orderedIds: List<Long>) = Unit
+
+        override suspend fun networkById(id: Long): NetworkEntity? = null
+
+        override suspend fun childrenOf(rootId: Long): List<NetworkEntity> = emptyList()
+    }
+
+    private class RecordingConnectionManager : NoopConnectionManager() {
+        override val connectionStates = MutableStateFlow<Map<Long, IrcClientState>>(emptyMap())
+        val markedRead = mutableListOf<Long>()
+
+        override suspend fun markRead(
+            bufferId: Long,
+            anchor: TimelineAnchor,
+        ) {
+            markedRead.add(bufferId)
+        }
+    }
+
+    private class FakeSettingsRepository : SettingsRepository {
+        override val settings =
+            MutableStateFlow(
+                Settings(ThemeMode.SYSTEM, true, DeliveryMode.PERSISTENT_SOCKET),
+            )
+
+        override suspend fun setThemeMode(m: ThemeMode) = Unit
+
+        override suspend fun setDynamicColor(enabled: Boolean) = Unit
+
+        override suspend fun setDeliveryMode(m: DeliveryMode) = Unit
+
+        override suspend fun setLayoutDensity(d: LayoutDensity) = Unit
+
+        override suspend fun setNickColorsEnabled(enabled: Boolean) = Unit
+
+        override suspend fun setNickColorPalette(p: NickColorPalette) = Unit
+
+        override suspend fun setNickColorOverride(
+            nick: String,
+            hue: Int?,
+        ) = Unit
+
+        override suspend fun setFriend(
+            nick: String,
+            isFriend: Boolean,
+        ) = Unit
+
+        override suspend fun setFool(
+            nick: String,
+            isFool: Boolean,
+        ) = Unit
+
+        override suspend fun setFoolsMode(m: FoolsMode) = Unit
+
+        override suspend fun setPresenceMode(m: PresenceMode) = Unit
+
+        override suspend fun setAvatarStyle(style: AvatarStyle) = Unit
+
+        override suspend fun setChatWallpaper(w: io.github.trevarj.motd.data.prefs.ChatWallpaper) = Unit
+
+        override suspend fun setShowComposerEmoji(show: Boolean) = Unit
+
+        override suspend fun setShowComposerFormattingTools(show: Boolean) = Unit
+
+        override suspend fun setChatSoundsEnabled(enabled: Boolean) = Unit
+
+        override suspend fun setHistorySyncDepth(d: io.github.trevarj.motd.data.prefs.HistorySyncDepth) = Unit
+
+        override suspend fun setAutoAwayEnabled(enabled: Boolean) = Unit
+
+        override suspend fun setAutoAwayMinutes(minutes: Int) = Unit
+
+        override suspend fun setAutoAwayMessage(message: String) = Unit
+    }
+
+    private class FakeAppVisibility : AppVisibility {
+        override val onScreen: StateFlow<Boolean> = MutableStateFlow(true).asStateFlow()
+    }
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun readMarker(bufferId: Long) = BufferReadMarker(bufferId, target = "#muted-channel", timestamp = 200, eventId = 9)
+
+    private fun mutedRow(bufferId: Long) =
+        ChatListRow(
+            bufferId = bufferId,
+            networkId = 1,
+            networkName = "libera",
+            displayName = "#muted-channel",
+            type = BufferType.CHANNEL,
+            pinned = false,
+            muted = true,
+            lastMessageText = "quiet",
+            lastMessageSender = "bot",
+            lastMessageTime = 100,
+            unreadCount = 5,
+            mentionCount = 0,
+        )
+
+    @Test
+    fun `markSelectedRead reaches a muted buffer that mark-all would have skipped`() =
+        runTest {
+            val bufferId = 7L
+            val rows = MutableStateFlow(listOf(mutedRow(bufferId)))
+            val connectionManager = RecordingConnectionManager()
+            val viewModel =
+                ChatListViewModel(
+                    bufferRepository = FakeBufferRepository(rows),
+                    networkRepository = FakeNetworkRepository(),
+                    connectionManager = connectionManager,
+                    historyResync =
+                        object : HistoryResyncController {
+                            override fun syncStatus(bufferId: Long) = flowOf<HistorySyncStatus>(HistorySyncStatus.Idle)
+
+                            override suspend fun reconcileBuffer(
+                                buffer: BufferEntity,
+                                client: IrcClient,
+                                isCurrent: () -> Boolean,
+                            ) = HistoryResyncState.Idle
+
+                            override suspend fun reconcilePendingMessage(
+                                buffer: BufferEntity,
+                                client: IrcClient,
+                                isCurrent: () -> Boolean,
+                            ) = HistoryResyncState.Idle
+                        },
+                    channelCloseCoordinator =
+                        object : ChannelCloseCoordinator {
+                            override fun start() = Unit
+
+                            override suspend fun requestClose(bufferId: Long) = Unit
+                        },
+                    readMarkerRepository =
+                        object : ReadMarkerSnapshotter {
+                            override suspend fun latestIncoming(bufferIds: Collection<Long>): List<BufferReadMarker> = bufferIds.map(::readMarker)
+                        },
+                    settingsRepository = FakeSettingsRepository(),
+                    onboardingPrefs =
+                        object : OnboardingPrefs {
+                            override val completed = flowOf(true)
+
+                            override suspend fun markCompleted() = Unit
+                        },
+                    savedStateHandle = SavedStateHandle(),
+                    appVisibility = FakeAppVisibility(),
+                )
+
+            // Sanity check: mark-all's own selector skips this row because it's muted.
+            assertEquals(emptyList<Long>(), unreadBufferIds(rows.value))
+
+            viewModel.markSelectedRead(listOf(bufferId))
+            runCurrent()
+
+            assertEquals(listOf(bufferId), connectionManager.markedRead)
+        }
+
+    @Test
+    fun `markSelectedRead with no ids does nothing`() =
+        runTest {
+            val connectionManager = RecordingConnectionManager()
+            val viewModel =
+                ChatListViewModel(
+                    bufferRepository = FakeBufferRepository(MutableStateFlow(emptyList())),
+                    networkRepository = FakeNetworkRepository(),
+                    connectionManager = connectionManager,
+                    historyResync =
+                        object : HistoryResyncController {
+                            override fun syncStatus(bufferId: Long) = flowOf<HistorySyncStatus>(HistorySyncStatus.Idle)
+
+                            override suspend fun reconcileBuffer(
+                                buffer: BufferEntity,
+                                client: IrcClient,
+                                isCurrent: () -> Boolean,
+                            ) = HistoryResyncState.Idle
+
+                            override suspend fun reconcilePendingMessage(
+                                buffer: BufferEntity,
+                                client: IrcClient,
+                                isCurrent: () -> Boolean,
+                            ) = HistoryResyncState.Idle
+                        },
+                    channelCloseCoordinator =
+                        object : ChannelCloseCoordinator {
+                            override fun start() = Unit
+
+                            override suspend fun requestClose(bufferId: Long) = Unit
+                        },
+                    readMarkerRepository =
+                        object : ReadMarkerSnapshotter {
+                            override suspend fun latestIncoming(bufferIds: Collection<Long>): List<BufferReadMarker> = emptyList()
+                        },
+                    settingsRepository = FakeSettingsRepository(),
+                    onboardingPrefs =
+                        object : OnboardingPrefs {
+                            override val completed = flowOf(true)
+
+                            override suspend fun markCompleted() = Unit
+                        },
+                    savedStateHandle = SavedStateHandle(),
+                    appVisibility = FakeAppVisibility(),
+                )
+
+            viewModel.markSelectedRead(emptyList())
+            runCurrent()
+
+            assertEquals(emptyList<Long>(), connectionManager.markedRead)
+        }
+}


### PR DESCRIPTION
## Summary
- `unreadChatRows`/mark-all deliberately skips muted rows (comment: "the whole point of muting is not to be told about activity ahead of time"), which means a muted chat's unread badge can only ever clear by opening it individually — it can grow indefinitely if you mute-and-forget.
- Add an explicit "mark as read" action to the chat-list multi-select toolbar, between mute and archive, using `Icons.Outlined.DoneAll` — the same icon the drawer's existing "mark all read" action already uses, for visual consistency.
- Unlike mark-all, this reaches every selected buffer regardless of mute state: hand-picking a row via long-press selection is an explicit opt-in, not an automatic sweep, so the muted exclusion doesn't apply here.
- `ChatListViewModel.markSelectedRead(bufferIds)` delegates to the same `markChatsRead` entry point `markCurrentScopeRead` uses, just without the `unreadBufferIds` mute filter.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.ui.chatlist.ChatListMarkSelectedReadTest` (new: asserts a muted row — which `unreadBufferIds` itself skips — still gets marked read via the explicit selection path, plus a no-op-on-empty-selection case)
- [x] `./gradlew assembleDebug`
- [x] Verified on-device: long-press select a muted chat, tap the new icon, its unread badge clears.