### PR TITLE
Revert "fix(chatlist): strip mIRC formatting codes from last-message preview" (#68)

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListRowItem.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -60,7 +59,6 @@ import io.github.trevarj.motd.audio.parseAudioAttachments
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.ChatListRow
 import io.github.trevarj.motd.data.prefs.TimeFormat
-import io.github.trevarj.motd.irc.format.plainIrcText
 import io.github.trevarj.motd.service.PresenceState
 import io.github.trevarj.motd.ui.components.AdvertisedActivityDot
 import io.github.trevarj.motd.ui.components.Avatar
@@ -158,12 +156,6 @@ internal sealed interface ChatListMessagePreview {
         val durationMs: Long?,
     ) : ChatListMessagePreview
 }
-
-/**
- * The preview line renders as plain text only: no color/bold/italic spans, just mIRC control codes
- * stripped (a color prefix like `\x0302` must not leak into the row as literal digits).
- */
-internal fun chatListPreviewText(text: String): AnnotatedString = AnnotatedString(plainIrcText(text))
 
 internal fun chatListMessagePreview(text: String?): ChatListMessagePreview {
     val value = text.orEmpty()
@@ -418,11 +410,12 @@ fun ChatListRowItem(
                     text =
                         when (preview) {
                             is ChatListMessagePreview.Text -> {
-                                chatListPreviewText(preview.value)
+                                androidx.compose.ui.text
+                                    .AnnotatedString(preview.value)
                             }
 
                             is ChatListMessagePreview.Voice -> {
-                                AnnotatedString(
+                                androidx.compose.ui.text.AnnotatedString(
                                     buildString {
                                         append(stringResource(R.string.chatlist_voice_message))
                                         preview.durationMs?.let { append(" · ${formatAudioDuration(it)}") }

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMessagePreviewTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListMessagePreviewTest.kt
@@ -7,15 +7,6 @@ import org.junit.Test
 
 class ChatListMessagePreviewTest {
     @Test
-    fun `preview strips mIRC control codes without adding formatting spans`() {
-        val colorCode = 0x03.toChar()
-        val raw = "[" + colorCode + "02OneFM" + colorCode + "] DJ: Auto DJ"
-        val preview = chatListPreviewText(raw)
-        assertEquals("[OneFM] DJ: Auto DJ", preview.text)
-        assertEquals(0, preview.spanStyles.size)
-    }
-
-    @Test
     fun `voice fallback becomes a compact voice preview`() {
         assertEquals(
             ChatListMessagePreview.Voice(durationMs = 14_000),


### PR DESCRIPTION
## Summary
This reverts #68 (commits cc7863da, 96e28381, 50e5fb4d).

- The last-message preview's text (`ChatListRow.lastMessageText`, backed by the `messages.text` column) is already produced by `EventProcessor` as the plain, control-code-stripped form at ingestion time (`storedText = formatted?.visibleText ?: routedText`). Routing it a second time through `plainIrcText` in the UI was always a no-op for correctly-ingested data — the digits/spans it "stripped" were never there to begin with.
- The original "02OneFM"-style bug that motivated #68 was traced to stale rows already sitting in a local dev database from before this ingestion-side stripping logic existed — not something a fresh install or the current ingestion pipeline can produce. Confirmed directly against the v0.15.1 release source, which already stores the same pre-stripped `text` column and renders correctly with no fix applied.
- Simplifying back to the original direct `AnnotatedString(preview.value)` call removes a redundant code path with no behavior change for real users.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.ui.chatlist.*`
- [x] `./gradlew assembleDebug`
- [x] Verified on-device: chat-list previews (e.g. RadioBot's `[OneFM] ...`) still render clean plain text with the revert applied.