### PR TITLE
fix(networks): dedup Add Network on name alone, not host/port/nick

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/data/repo/NetworkRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/repo/NetworkRepositoryImpl.kt
@@ -72,21 +72,37 @@ class NetworkRepositoryImpl
  *  case-insensitive). Hostnames are ASCII so [lowercase] with the default locale is safe. */
 internal fun normalizeHost(host: String): String = host.trim().trimEnd('.').lowercase()
 
+/** Normalize a network display name for identity comparison: trim and lowercase. */
+internal fun normalizeNetworkName(name: String): String = name.trim().lowercase()
+
+/**
+ * True when [name] collides (case-insensitively) with an existing DIRECT/BOUNCER_ROOT network.
+ * Lets a caller (the "Add network" form) surface a clear error before [NetworkRepositoryImpl.addNetwork]
+ * would otherwise silently reuse that row instead of creating a new one.
+ */
+fun networkNameTaken(
+    name: String,
+    existing: List<NetworkEntity>,
+): Boolean {
+    val normalized = normalizeNetworkName(name)
+    return existing.any { it.role != NetworkRole.BOUNCER_CHILD && normalizeNetworkName(it.name) == normalized }
+}
+
 /**
  * Stable identity key deciding whether two [NetworkEntity] rows are the same server, used by
  * [NetworkRepositoryImpl.addNetwork] to reject duplicates. Keyed per role:
  *
  * - **BOUNCER_CHILD**: `(parentId, bouncerNetId)` — a child is one bouncer-side network under one
  *   root, regardless of host (the mirror may not know the host yet). Guards both the onboarding
- *   import loop and the notify-mirror racing to insert the same child.
- * - **BOUNCER_ROOT**: `(host, port, saslUser)` — one soju account (login) per host:port. Adding
- *   the same bouncer account twice reuses the existing root.
- * - **DIRECT**: `(host, port, nick, bouncer selector?)` — ordinary direct rows use the first
- *   three; ZNC's slash-bearing SASL authcid or CLoak's PASS `user/network:password` adds the
- *   selected upstream network so one endpoint can hold more than one bouncer network.
- *
- * A `null` sub-key element is kept distinct (encoded as an empty segment) so under-specified rows
- * don't collapse onto each other.
+ *   import loop and the notify-mirror racing to insert the same child. This is an internal sync
+ *   mechanism (soju LISTNETWORKS import), not a user-facing add path, so it is untouched by the
+ *   name-based scheme below.
+ * - **BOUNCER_ROOT** and **DIRECT**: `name` alone. Users are responsible for filling in
+ *   host/port/nick/credentials correctly; matching on those fields silently merged distinct rows
+ *   that legitimately share an endpoint (e.g. two accounts on the same relay), which read as a
+ *   broken "Add network" with no feedback. A duplicate *name* is still rejected so re-running
+ *   onboarding for a server the user already added (e.g. picking the Libera preset twice) reuses
+ *   the existing row instead of creating a same-named duplicate.
  */
 internal fun networkIdentityKey(n: NetworkEntity): String =
     when (n.role) {
@@ -94,23 +110,7 @@ internal fun networkIdentityKey(n: NetworkEntity): String =
             "child|${n.parentId}|${n.bouncerNetId.orEmpty()}"
         }
 
-        NetworkRole.BOUNCER_ROOT -> {
-            "root|${normalizeHost(n.host)}|${n.port}|${n.saslUser.orEmpty()}"
-        }
-
-        NetworkRole.DIRECT -> {
-            // ZNC selects an upstream in its SASL authcid; CLoak does so in the non-secret prefix of
-            // PASS. Keep only that selector in the key so passwords never become identity material.
-            val saslSelector = n.saslUser?.takeIf { '/' in it }
-            val passSelector = n.serverPassword?.let(::serverPasswordSelector)
-            val bouncerSelector = saslSelector ?: passSelector.orEmpty()
-            "direct|${normalizeHost(n.host)}|${n.port}|${n.nick}|$bouncerSelector"
+        NetworkRole.BOUNCER_ROOT, NetworkRole.DIRECT -> {
+            "name|${normalizeNetworkName(n.name)}"
         }
     }
-
-/** Extract CLoak's `user/network` selector without retaining its trailing password. */
-private fun serverPasswordSelector(password: String): String? {
-    val slash = password.indexOf('/')
-    val colon = password.lastIndexOf(':')
-    return password.substring(0, colon).takeIf { slash >= 0 && colon > slash }
-}

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/repo/NetworkRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/repo/NetworkRepositoryImpl.kt
@@ -72,37 +72,21 @@ class NetworkRepositoryImpl
  *  case-insensitive). Hostnames are ASCII so [lowercase] with the default locale is safe. */
 internal fun normalizeHost(host: String): String = host.trim().trimEnd('.').lowercase()
 
-/** Normalize a network display name for identity comparison: trim and lowercase. */
-internal fun normalizeNetworkName(name: String): String = name.trim().lowercase()
-
-/**
- * True when [name] collides (case-insensitively) with an existing DIRECT/BOUNCER_ROOT network.
- * Lets a caller (the "Add network" form) surface a clear error before [NetworkRepositoryImpl.addNetwork]
- * would otherwise silently reuse that row instead of creating a new one.
- */
-fun networkNameTaken(
-    name: String,
-    existing: List<NetworkEntity>,
-): Boolean {
-    val normalized = normalizeNetworkName(name)
-    return existing.any { it.role != NetworkRole.BOUNCER_CHILD && normalizeNetworkName(it.name) == normalized }
-}
-
 /**
  * Stable identity key deciding whether two [NetworkEntity] rows are the same server, used by
  * [NetworkRepositoryImpl.addNetwork] to reject duplicates. Keyed per role:
  *
  * - **BOUNCER_CHILD**: `(parentId, bouncerNetId)` — a child is one bouncer-side network under one
  *   root, regardless of host (the mirror may not know the host yet). Guards both the onboarding
- *   import loop and the notify-mirror racing to insert the same child. This is an internal sync
- *   mechanism (soju LISTNETWORKS import), not a user-facing add path, so it is untouched by the
- *   name-based scheme below.
- * - **BOUNCER_ROOT** and **DIRECT**: `name` alone. Users are responsible for filling in
- *   host/port/nick/credentials correctly; matching on those fields silently merged distinct rows
- *   that legitimately share an endpoint (e.g. two accounts on the same relay), which read as a
- *   broken "Add network" with no feedback. A duplicate *name* is still rejected so re-running
- *   onboarding for a server the user already added (e.g. picking the Libera preset twice) reuses
- *   the existing row instead of creating a same-named duplicate.
+ *   import loop and the notify-mirror racing to insert the same child.
+ * - **BOUNCER_ROOT**: `(host, port, saslUser)` — one soju account (login) per host:port. Adding
+ *   the same bouncer account twice reuses the existing root.
+ * - **DIRECT**: `(host, port, nick, username, SASL authcid, relay selector?)` — account identity
+ *   keeps multiple logins on one endpoint distinct. CLoak's PASS `user/network:password` and
+ *   WeeChat relays' `network:password` contribute only their non-secret selector.
+ *
+ * A `null` sub-key element is kept distinct (encoded as an empty segment) so under-specified rows
+ * don't collapse onto each other.
  */
 internal fun networkIdentityKey(n: NetworkEntity): String =
     when (n.role) {
@@ -110,7 +94,20 @@ internal fun networkIdentityKey(n: NetworkEntity): String =
             "child|${n.parentId}|${n.bouncerNetId.orEmpty()}"
         }
 
-        NetworkRole.BOUNCER_ROOT, NetworkRole.DIRECT -> {
-            "name|${normalizeNetworkName(n.name)}"
+        NetworkRole.BOUNCER_ROOT -> {
+            "root|${normalizeHost(n.host)}|${n.port}|${n.saslUser.orEmpty()}"
+        }
+
+        NetworkRole.DIRECT -> {
+            // Keep credentials out of the key. SASL authcid and relay PASS prefixes identify the
+            // account/network without retaining either password.
+            val passSelector = n.serverPassword?.let(::serverPasswordSelector).orEmpty()
+            "direct|${normalizeHost(n.host)}|${n.port}|${n.nick}|${n.username}|${n.saslUser.orEmpty()}|$passSelector"
         }
     }
+
+/** Extract a relay's `network` or `user/network` selector without retaining its password. */
+private fun serverPasswordSelector(password: String): String? {
+    val colon = password.indexOf(':')
+    return password.substring(0, colon).takeIf { colon > 0 }
+}

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
@@ -201,13 +201,6 @@ fun AddNetworkContent(
                                         ?: state.server.host.ifBlank { stringResource(R.string.add_network_kind_network) },
                                 )
                             },
-                            isError = state.nameConflict,
-                            supportingText =
-                                if (state.nameConflict) {
-                                    { Text(stringResource(R.string.add_network_name_taken)) }
-                                } else {
-                                    null
-                                },
                             singleLine = true,
                             modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("add_network_display_name"),
                         )
@@ -239,15 +232,12 @@ fun AddNetworkContent(
                         }
                     }
                 }
-                // ZNC hides the display-name field (its network name lives in BouncerLoginFields
-                // instead), so the inline field error above never renders for it; this is the only
-                // place a ZNC name conflict becomes visible.
-                if (state.nameConflict && state.isZnc) {
+                if (state.duplicateConnection) {
                     Text(
-                        text = stringResource(R.string.add_network_name_taken),
+                        text = stringResource(R.string.add_network_duplicate),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.testTag("add_network_name_conflict"),
+                        modifier = Modifier.testTag("add_network_duplicate"),
                     )
                 }
                 Button(

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkScreen.kt
@@ -201,6 +201,13 @@ fun AddNetworkContent(
                                         ?: state.server.host.ifBlank { stringResource(R.string.add_network_kind_network) },
                                 )
                             },
+                            isError = state.nameConflict,
+                            supportingText =
+                                if (state.nameConflict) {
+                                    { Text(stringResource(R.string.add_network_name_taken)) }
+                                } else {
+                                    null
+                                },
                             singleLine = true,
                             modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("add_network_display_name"),
                         )
@@ -231,6 +238,17 @@ fun AddNetworkContent(
                             )
                         }
                     }
+                }
+                // ZNC hides the display-name field (its network name lives in BouncerLoginFields
+                // instead), so the inline field error above never renders for it; this is the only
+                // place a ZNC name conflict becomes visible.
+                if (state.nameConflict && state.isZnc) {
+                    Text(
+                        text = stringResource(R.string.add_network_name_taken),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.testTag("add_network_name_conflict"),
+                    )
                 }
                 Button(
                     onClick = onSubmit,

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
@@ -11,6 +11,7 @@ import io.github.trevarj.motd.data.prefs.BouncerKindPrefs
 import io.github.trevarj.motd.data.prefs.NoopBouncerKindPrefs
 import io.github.trevarj.motd.data.prefs.PresetEnrollmentPrefs
 import io.github.trevarj.motd.data.repo.NetworkRepository
+import io.github.trevarj.motd.data.repo.networkNameTaken
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.ui.onboarding.AuthForm
@@ -48,6 +49,8 @@ data class AddNetworkUiState(
     val presetId: NetworkPresetId = NetworkPresetId.CUSTOM,
     val showPlaintextWarning: Boolean = false,
     val plaintextConfirmed: Boolean = false,
+    /** True when [submit] rejected this name as already in use by another network. */
+    val nameConflict: Boolean = false,
 ) {
     val isBouncer: Boolean get() = kind == ConnectionChoice.BOUNCER
     val isSoju: Boolean get() = isBouncer && bouncerKind == BouncerKind.SOJU
@@ -98,6 +101,7 @@ class AddNetworkViewModel
                     presetId = if (kind == ConnectionChoice.NETWORK) _state.value.presetId else NetworkPresetId.CUSTOM,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
+                    nameConflict = false,
                 )
         }
 
@@ -107,6 +111,7 @@ class AddNetworkViewModel
                     bouncerKind = kind,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
+                    nameConflict = false,
                 )
         }
 
@@ -119,6 +124,7 @@ class AddNetworkViewModel
                     presetId = if (selected?.matches(server) == true) current.presetId else NetworkPresetId.CUSTOM,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
+                    nameConflict = false,
                 )
         }
 
@@ -131,6 +137,7 @@ class AddNetworkViewModel
                         presetId = NetworkPresetId.CUSTOM,
                         showPlaintextWarning = false,
                         plaintextConfirmed = false,
+                        nameConflict = false,
                     )
                 return
             }
@@ -143,11 +150,12 @@ class AddNetworkViewModel
                     presetId = id,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
+                    nameConflict = false,
                 )
         }
 
         fun editDisplayName(name: String) {
-            _state.value = _state.value.copy(displayName = name)
+            _state.value = _state.value.copy(displayName = name, nameConflict = false)
         }
 
         fun editAuth(auth: AuthForm) {
@@ -159,7 +167,7 @@ class AddNetworkViewModel
         }
 
         fun editZncLogin(login: ZncLoginForm) {
-            _state.value = _state.value.copy(zncLogin = login)
+            _state.value = _state.value.copy(zncLogin = login, nameConflict = false)
         }
 
         /** Create the row, connect, and observe its live state. */
@@ -185,19 +193,28 @@ class AddNetworkViewModel
                         } else {
                             s.server
                         }
+                    val effectiveName =
+                        when {
+                            s.isZnc -> s.zncLogin.network.trim()
+                            s.displayName.isNotBlank() -> s.displayName.trim()
+                            else -> networkPreset(s.presetId)?.displayName ?: s.server.host
+                        }
+                    val existingNetworks = networkRepository.observeNetworks().first()
+                    if (networkNameTaken(effectiveName, existingNetworks)) {
+                        // Surface this instead of letting addNetwork's dedup silently reuse the
+                        // existing row: that reconnected an already-live network and closed the
+                        // form with zero feedback, which read as "Save just does nothing."
+                        _state.value = _state.value.copy(nameConflict = true)
+                        return@launch
+                    }
                     val entity =
                         buildNetworkEntity(
                             server = server,
                             auth = s.activeAuth,
                             role = s.role,
-                            name =
-                                when {
-                                    s.isZnc -> s.zncLogin.network.trim()
-                                    s.displayName.isNotBlank() -> s.displayName.trim()
-                                    else -> networkPreset(s.presetId)?.displayName ?: s.server.host
-                                },
+                            name = effectiveName,
                         )
-                    val existingNetworkIds = networkRepository.observeNetworks().first().mapTo(mutableSetOf()) { it.id }
+                    val existingNetworkIds = existingNetworks.mapTo(mutableSetOf()) { it.id }
                     val networkId = networkRepository.addNetwork(entity)
                     if (networkId !in existingNetworkIds && s.presetId == NetworkPresetId.LIBERA) {
                         presetEnrollmentPrefs.markLiberaEligible(networkId)

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/settings/addnetwork/AddNetworkViewModel.kt
@@ -11,7 +11,6 @@ import io.github.trevarj.motd.data.prefs.BouncerKindPrefs
 import io.github.trevarj.motd.data.prefs.NoopBouncerKindPrefs
 import io.github.trevarj.motd.data.prefs.PresetEnrollmentPrefs
 import io.github.trevarj.motd.data.repo.NetworkRepository
-import io.github.trevarj.motd.data.repo.networkNameTaken
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.ui.onboarding.AuthForm
@@ -49,8 +48,8 @@ data class AddNetworkUiState(
     val presetId: NetworkPresetId = NetworkPresetId.CUSTOM,
     val showPlaintextWarning: Boolean = false,
     val plaintextConfirmed: Boolean = false,
-    /** True when [submit] rejected this name as already in use by another network. */
-    val nameConflict: Boolean = false,
+    /** True when [submit] resolves to an existing connection instead of creating a new row. */
+    val duplicateConnection: Boolean = false,
 ) {
     val isBouncer: Boolean get() = kind == ConnectionChoice.BOUNCER
     val isSoju: Boolean get() = isBouncer && bouncerKind == BouncerKind.SOJU
@@ -101,7 +100,7 @@ class AddNetworkViewModel
                     presetId = if (kind == ConnectionChoice.NETWORK) _state.value.presetId else NetworkPresetId.CUSTOM,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
-                    nameConflict = false,
+                    duplicateConnection = false,
                 )
         }
 
@@ -111,7 +110,7 @@ class AddNetworkViewModel
                     bouncerKind = kind,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
-                    nameConflict = false,
+                    duplicateConnection = false,
                 )
         }
 
@@ -124,7 +123,7 @@ class AddNetworkViewModel
                     presetId = if (selected?.matches(server) == true) current.presetId else NetworkPresetId.CUSTOM,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
-                    nameConflict = false,
+                    duplicateConnection = false,
                 )
         }
 
@@ -137,7 +136,7 @@ class AddNetworkViewModel
                         presetId = NetworkPresetId.CUSTOM,
                         showPlaintextWarning = false,
                         plaintextConfirmed = false,
-                        nameConflict = false,
+                        duplicateConnection = false,
                     )
                 return
             }
@@ -150,24 +149,24 @@ class AddNetworkViewModel
                     presetId = id,
                     showPlaintextWarning = false,
                     plaintextConfirmed = false,
-                    nameConflict = false,
+                    duplicateConnection = false,
                 )
         }
 
         fun editDisplayName(name: String) {
-            _state.value = _state.value.copy(displayName = name, nameConflict = false)
+            _state.value = _state.value.copy(displayName = name, duplicateConnection = false)
         }
 
         fun editAuth(auth: AuthForm) {
-            _state.value = _state.value.copy(auth = auth)
+            _state.value = _state.value.copy(auth = auth, duplicateConnection = false)
         }
 
         fun editSojuLogin(login: SojuLoginForm) {
-            _state.value = _state.value.copy(sojuLogin = login)
+            _state.value = _state.value.copy(sojuLogin = login, duplicateConnection = false)
         }
 
         fun editZncLogin(login: ZncLoginForm) {
-            _state.value = _state.value.copy(zncLogin = login, nameConflict = false)
+            _state.value = _state.value.copy(zncLogin = login, duplicateConnection = false)
         }
 
         /** Create the row, connect, and observe its live state. */
@@ -200,13 +199,6 @@ class AddNetworkViewModel
                             else -> networkPreset(s.presetId)?.displayName ?: s.server.host
                         }
                     val existingNetworks = networkRepository.observeNetworks().first()
-                    if (networkNameTaken(effectiveName, existingNetworks)) {
-                        // Surface this instead of letting addNetwork's dedup silently reuse the
-                        // existing row: that reconnected an already-live network and closed the
-                        // form with zero feedback, which read as "Save just does nothing."
-                        _state.value = _state.value.copy(nameConflict = true)
-                        return@launch
-                    }
                     val entity =
                         buildNetworkEntity(
                             server = server,
@@ -216,9 +208,13 @@ class AddNetworkViewModel
                         )
                     val existingNetworkIds = existingNetworks.mapTo(mutableSetOf()) { it.id }
                     val networkId = networkRepository.addNetwork(entity)
-                    if (networkId !in existingNetworkIds && s.presetId == NetworkPresetId.LIBERA) {
-                        presetEnrollmentPrefs.markLiberaEligible(networkId)
+                    if (networkId in existingNetworkIds) {
+                        // Do not reconnect and close the form when repository dedup finds this exact
+                        // connection. Keep every field intact so user can change account details.
+                        _state.value = _state.value.copy(duplicateConnection = true)
+                        return@launch
                     }
+                    if (s.presetId == NetworkPresetId.LIBERA) presetEnrollmentPrefs.markLiberaEligible(networkId)
                     _state.value =
                         _state.value.copy(
                             phase = AddNetworkPhase.TESTING,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -909,7 +909,7 @@
     <string name="add_network_kind_network">IRC network</string>
     <string name="add_network_kind_bouncer">Bouncer</string>
     <string name="add_network_connect_save">Connect &amp; save</string>
-    <string name="add_network_name_taken">A network with this name already exists. Choose a different name.</string>
+    <string name="add_network_duplicate">This connection already exists. Change its account or network details.</string>
     <string name="add_network_testing">Testing connection…</string>
     <string name="add_network_edit">Edit</string>
     <string name="add_network_save_anyway">Save anyway</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -909,6 +909,7 @@
     <string name="add_network_kind_network">IRC network</string>
     <string name="add_network_kind_bouncer">Bouncer</string>
     <string name="add_network_connect_save">Connect &amp; save</string>
+    <string name="add_network_name_taken">A network with this name already exists. Choose a different name.</string>
     <string name="add_network_testing">Testing connection…</string>
     <string name="add_network_edit">Edit</string>
     <string name="add_network_save_anyway">Save anyway</string>

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/repo/NetworkDedupTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/repo/NetworkDedupTest.kt
@@ -16,9 +16,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Duplicate-connection prevention: adding the same server twice must not
- * insert a second [NetworkEntity] (which would spawn a second actor/socket). Covers the
- * per-role identity key and the idempotent soju-child import.
+ * Duplicate-connection prevention: adding the same server twice must not insert a second
+ * [NetworkEntity] (which would spawn a second actor/socket). DIRECT and BOUNCER_ROOT dedup on
+ * [name][NetworkEntity.name] alone — host/port/nick/credential differences never block a second
+ * add (see [networkIdentityKey]: users filling those in incorrectly, e.g. a WeeChat relay account
+ * missing the ZNC/CLoak `user/network` selector, must not have it silently merged into an
+ * unrelated existing network). BOUNCER_CHILD keeps its own `(parentId, bouncerNetId)` key, since
+ * that path is the soju-child import, not a user-facing add.
  */
 class NetworkDedupTest {
     /** In-memory NetworkDao: only the methods addNetwork touches are backed; rest throw. */
@@ -115,11 +119,12 @@ class NetworkDedupTest {
     }
 
     private fun direct(
-        host: String,
+        name: String,
+        host: String = name,
         port: Int = 6697,
         nick: String = "motd",
     ) = NetworkEntity(
-        name = host,
+        name = name,
         role = NetworkRole.DIRECT,
         host = host,
         port = port,
@@ -129,10 +134,11 @@ class NetworkDedupTest {
     )
 
     private fun root(
-        host: String,
+        name: String,
         saslUser: String?,
+        host: String = name,
     ) = NetworkEntity(
-        name = host,
+        name = name,
         role = NetworkRole.BOUNCER_ROOT,
         host = host,
         port = 6697,
@@ -160,12 +166,12 @@ class NetworkDedupTest {
     )
 
     @Test
-    fun `adding the same direct server twice returns the existing id and no second row`() =
+    fun `adding the same name twice returns the existing id and no second row`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val first = repo.addNetwork(direct("irc.libera.chat"))
-            val second = repo.addNetwork(direct("irc.libera.chat"))
+            val first = repo.addNetwork(direct("Libera"))
+            val second = repo.addNetwork(direct("Libera"))
             assertEquals(first, second)
             assertEquals(1, dao.rows.size)
         }
@@ -176,100 +182,81 @@ class NetworkDedupTest {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
 
-            val ids = List(20) { async { repo.addNetwork(direct("irc.libera.chat")) } }.awaitAll()
+            val ids = List(20) { async { repo.addNetwork(direct("Libera")) } }.awaitAll()
 
             assertEquals(1, ids.toSet().size)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `host normalization dedups trailing-dot and case variants`() =
+    fun `name normalization dedups whitespace and case variants`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val a = repo.addNetwork(direct("irc.libera.chat"))
-            val b = repo.addNetwork(direct("IRC.Libera.Chat."))
+            val a = repo.addNetwork(direct("Libera"))
+            val b = repo.addNetwork(direct("  libera  "))
             assertEquals(a, b)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `different nick on the same server is a distinct network`() =
-        runBlocking {
-            val dao = InMemoryNetworkDao()
-            val repo = NetworkRepositoryImpl(dao)
-            repo.addNetwork(direct("irc.libera.chat", nick = "alice"))
-            repo.addNetwork(direct("irc.libera.chat", nick = "bob"))
-            assertEquals(2, dao.rows.size)
-        }
+    fun `networkNameTaken matches case-insensitively and ignores bouncer children`() {
+        val existing =
+            listOf(
+                direct("Libera").copy(id = 1),
+                child(parentId = 2, netId = "1").copy(id = 3, name = "Libera"),
+            )
+        assertEquals(true, networkNameTaken("libera", existing))
+        assertEquals(true, networkNameTaken("  LIBERA  ", existing))
+        assertEquals(false, networkNameTaken("OFTC", existing))
+        // The BOUNCER_CHILD row happens to share the name "Libera" but must not count: it is an
+        // internal soju mirror, not a name the "Add network" form could ever collide with.
+        assertEquals(false, networkNameTaken("Libera", listOf(child(parentId = 2, netId = "1").copy(name = "Libera"))))
+    }
 
     @Test
-    fun `different ZNC network selectors on one endpoint stay distinct`() =
+    fun `same name but different host, port, or nick still dedups`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val seed = direct("znc.example.org").copy(saslMechanism = "PLAIN", saslUser = "motd/libera")
-            repo.addNetwork(seed)
-            repo.addNetwork(seed.copy(name = "oftc", saslUser = "motd/oftc"))
-            assertEquals(2, dao.rows.size)
-        }
-
-    @Test
-    fun `same ZNC selector deduplicates`() =
-        runBlocking {
-            val dao = InMemoryNetworkDao()
-            val repo = NetworkRepositoryImpl(dao)
-            val seed = direct("znc.example.org").copy(saslMechanism = "PLAIN", saslUser = "motd/libera")
-            val first = repo.addNetwork(seed)
-            val second = repo.addNetwork(seed.copy(name = "renamed"))
+            val first =
+                repo.addNetwork(
+                    direct("relay", host = "myweechat.0bin.xyz", port = 1343, nick = "alice"),
+                )
+            // Same display name, everything else differs (the WeeChat-relay dedup complaint):
+            // whatever host/port/nick/credentials the user typed the second time, a name collision
+            // alone must still resolve to the existing row rather than silently connecting twice.
+            val second =
+                repo.addNetwork(
+                    direct("relay", host = "myweechat.0bin.xyz", port = 1343, nick = "PeGaSuS"),
+                )
             assertEquals(first, second)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `different CLoak network selectors on one endpoint stay distinct`() =
+    fun `different name on the same host, port, and nick is a distinct network`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val seed = direct("cloak.example.org").copy(serverPassword = "motd/libera:secret")
-            repo.addNetwork(seed)
-            repo.addNetwork(seed.copy(name = "oftc", serverPassword = "motd/oftc:secret"))
+            // The motivating case: a second account on the same relay. Host/port/nick alone must
+            // never merge two rows the user explicitly named differently.
+            repo.addNetwork(direct("01_ptirc", host = "myweechat.0bin.xyz", port = 1343))
+            repo.addNetwork(direct("02_libera", host = "myweechat.0bin.xyz", port = 1343))
             assertEquals(2, dao.rows.size)
         }
 
     @Test
-    fun `same CLoak selector deduplicates without using its password`() =
+    fun `same bouncer root name added twice reuses the row`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val seed = direct("cloak.example.org").copy(serverPassword = "motd/libera:old-secret")
-            val first = repo.addNetwork(seed)
-            val second = repo.addNetwork(seed.copy(name = "renamed", serverPassword = "motd/libera:new-secret"))
-            assertEquals(first, second)
-            assertEquals(1, dao.rows.size)
-        }
-
-    @Test
-    fun `different port is a distinct network`() =
-        runBlocking {
-            val dao = InMemoryNetworkDao()
-            val repo = NetworkRepositoryImpl(dao)
-            repo.addNetwork(direct("irc.libera.chat", port = 6697))
-            repo.addNetwork(direct("irc.libera.chat", port = 6667))
-            assertEquals(2, dao.rows.size)
-        }
-
-    @Test
-    fun `same bouncer account added twice reuses the root`() =
-        runBlocking {
-            val dao = InMemoryNetworkDao()
-            val repo = NetworkRepositoryImpl(dao)
-            val a = repo.addNetwork(root("bnc.example.org", saslUser = "acct"))
-            val b = repo.addNetwork(root("bnc.example.org", saslUser = "acct"))
+            val a = repo.addNetwork(root("My Bouncer", saslUser = "acct"))
+            val b = repo.addNetwork(root("My Bouncer", saslUser = "acct"))
             assertEquals(a, b)
             assertEquals(1, dao.rows.size)
-            // A different soju login on the same host is a distinct root.
-            repo.addNetwork(root("bnc.example.org", saslUser = "other"))
+            // A different name is a distinct root even with the same saslUser/host.
+            repo.addNetwork(root("Other Bouncer", saslUser = "acct", host = "bnc.example.org"))
             assertEquals(2, dao.rows.size)
         }
 

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/repo/NetworkDedupTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/repo/NetworkDedupTest.kt
@@ -16,13 +16,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Duplicate-connection prevention: adding the same server twice must not insert a second
- * [NetworkEntity] (which would spawn a second actor/socket). DIRECT and BOUNCER_ROOT dedup on
- * [name][NetworkEntity.name] alone — host/port/nick/credential differences never block a second
- * add (see [networkIdentityKey]: users filling those in incorrectly, e.g. a WeeChat relay account
- * missing the ZNC/CLoak `user/network` selector, must not have it silently merged into an
- * unrelated existing network). BOUNCER_CHILD keeps its own `(parentId, bouncerNetId)` key, since
- * that path is the soju-child import, not a user-facing add.
+ * Duplicate-connection prevention: adding the same server twice must not
+ * insert a second [NetworkEntity] (which would spawn a second actor/socket). Covers the
+ * per-role identity key and the idempotent soju-child import.
  */
 class NetworkDedupTest {
     /** In-memory NetworkDao: only the methods addNetwork touches are backed; rest throw. */
@@ -119,12 +115,11 @@ class NetworkDedupTest {
     }
 
     private fun direct(
-        name: String,
-        host: String = name,
+        host: String,
         port: Int = 6697,
         nick: String = "motd",
     ) = NetworkEntity(
-        name = name,
+        name = host,
         role = NetworkRole.DIRECT,
         host = host,
         port = port,
@@ -134,11 +129,10 @@ class NetworkDedupTest {
     )
 
     private fun root(
-        name: String,
+        host: String,
         saslUser: String?,
-        host: String = name,
     ) = NetworkEntity(
-        name = name,
+        name = host,
         role = NetworkRole.BOUNCER_ROOT,
         host = host,
         port = 6697,
@@ -166,12 +160,12 @@ class NetworkDedupTest {
     )
 
     @Test
-    fun `adding the same name twice returns the existing id and no second row`() =
+    fun `adding the same direct server twice returns the existing id and no second row`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val first = repo.addNetwork(direct("Libera"))
-            val second = repo.addNetwork(direct("Libera"))
+            val first = repo.addNetwork(direct("irc.libera.chat"))
+            val second = repo.addNetwork(direct("irc.libera.chat"))
             assertEquals(first, second)
             assertEquals(1, dao.rows.size)
         }
@@ -182,81 +176,145 @@ class NetworkDedupTest {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
 
-            val ids = List(20) { async { repo.addNetwork(direct("Libera")) } }.awaitAll()
+            val ids = List(20) { async { repo.addNetwork(direct("irc.libera.chat")) } }.awaitAll()
 
             assertEquals(1, ids.toSet().size)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `name normalization dedups whitespace and case variants`() =
+    fun `host normalization dedups trailing-dot and case variants`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val a = repo.addNetwork(direct("Libera"))
-            val b = repo.addNetwork(direct("  libera  "))
+            val a = repo.addNetwork(direct("irc.libera.chat"))
+            val b = repo.addNetwork(direct("IRC.Libera.Chat."))
             assertEquals(a, b)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `networkNameTaken matches case-insensitively and ignores bouncer children`() {
-        val existing =
-            listOf(
-                direct("Libera").copy(id = 1),
-                child(parentId = 2, netId = "1").copy(id = 3, name = "Libera"),
-            )
-        assertEquals(true, networkNameTaken("libera", existing))
-        assertEquals(true, networkNameTaken("  LIBERA  ", existing))
-        assertEquals(false, networkNameTaken("OFTC", existing))
-        // The BOUNCER_CHILD row happens to share the name "Libera" but must not count: it is an
-        // internal soju mirror, not a name the "Add network" form could ever collide with.
-        assertEquals(false, networkNameTaken("Libera", listOf(child(parentId = 2, netId = "1").copy(name = "Libera"))))
-    }
-
-    @Test
-    fun `same name but different host, port, or nick still dedups`() =
+    fun `different nick on the same server is a distinct network`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val first =
-                repo.addNetwork(
-                    direct("relay", host = "myweechat.0bin.xyz", port = 1343, nick = "alice"),
-                )
-            // Same display name, everything else differs (the WeeChat-relay dedup complaint):
-            // whatever host/port/nick/credentials the user typed the second time, a name collision
-            // alone must still resolve to the existing row rather than silently connecting twice.
-            val second =
-                repo.addNetwork(
-                    direct("relay", host = "myweechat.0bin.xyz", port = 1343, nick = "PeGaSuS"),
-                )
+            repo.addNetwork(direct("irc.libera.chat", nick = "alice"))
+            repo.addNetwork(direct("irc.libera.chat", nick = "bob"))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `different ZNC network selectors on one endpoint stay distinct`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("znc.example.org").copy(saslMechanism = "PLAIN", saslUser = "motd/libera")
+            repo.addNetwork(seed)
+            repo.addNetwork(seed.copy(name = "oftc", saslUser = "motd/oftc"))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `same ZNC selector deduplicates`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("znc.example.org").copy(saslMechanism = "PLAIN", saslUser = "motd/libera")
+            val first = repo.addNetwork(seed)
+            val second = repo.addNetwork(seed.copy(name = "renamed"))
             assertEquals(first, second)
             assertEquals(1, dao.rows.size)
         }
 
     @Test
-    fun `different name on the same host, port, and nick is a distinct network`() =
+    fun `different SASL accounts on one endpoint stay distinct`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            // The motivating case: a second account on the same relay. Host/port/nick alone must
-            // never merge two rows the user explicitly named differently.
-            repo.addNetwork(direct("01_ptirc", host = "myweechat.0bin.xyz", port = 1343))
-            repo.addNetwork(direct("02_libera", host = "myweechat.0bin.xyz", port = 1343))
+            val seed = direct("relay.example.org").copy(saslMechanism = "PLAIN", saslUser = "alice")
+            repo.addNetwork(seed)
+            repo.addNetwork(seed.copy(name = "bob", saslUser = "bob"))
             assertEquals(2, dao.rows.size)
         }
 
     @Test
-    fun `same bouncer root name added twice reuses the row`() =
+    fun `different USER identities on one endpoint stay distinct`() =
         runBlocking {
             val dao = InMemoryNetworkDao()
             val repo = NetworkRepositoryImpl(dao)
-            val a = repo.addNetwork(root("My Bouncer", saslUser = "acct"))
-            val b = repo.addNetwork(root("My Bouncer", saslUser = "acct"))
+            val seed = direct("relay.example.org").copy(username = "alice")
+            repo.addNetwork(seed)
+            repo.addNetwork(seed.copy(name = "bob", username = "bob"))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `different WeeChat relay selectors on one endpoint stay distinct`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("myweechat.0bin.xyz", port = 1343).copy(serverPassword = "01_ptirc:secret")
+            repo.addNetwork(seed)
+            repo.addNetwork(seed.copy(name = "02_libera", serverPassword = "02_libera:secret"))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `same WeeChat relay selector deduplicates without using its password`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("myweechat.0bin.xyz", port = 1343).copy(serverPassword = "01_ptirc:old-secret")
+            val first = repo.addNetwork(seed)
+            val second = repo.addNetwork(seed.copy(name = "renamed", serverPassword = "01_ptirc:new:secret"))
+            assertEquals(first, second)
+            assertEquals(1, dao.rows.size)
+        }
+
+    @Test
+    fun `different CLoak network selectors on one endpoint stay distinct`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("cloak.example.org").copy(serverPassword = "motd/libera:secret")
+            repo.addNetwork(seed)
+            repo.addNetwork(seed.copy(name = "oftc", serverPassword = "motd/oftc:secret"))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `same CLoak selector deduplicates without using its password`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val seed = direct("cloak.example.org").copy(serverPassword = "motd/libera:old-secret")
+            val first = repo.addNetwork(seed)
+            val second = repo.addNetwork(seed.copy(name = "renamed", serverPassword = "motd/libera:new-secret"))
+            assertEquals(first, second)
+            assertEquals(1, dao.rows.size)
+        }
+
+    @Test
+    fun `different port is a distinct network`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            repo.addNetwork(direct("irc.libera.chat", port = 6697))
+            repo.addNetwork(direct("irc.libera.chat", port = 6667))
+            assertEquals(2, dao.rows.size)
+        }
+
+    @Test
+    fun `same bouncer account added twice reuses the root`() =
+        runBlocking {
+            val dao = InMemoryNetworkDao()
+            val repo = NetworkRepositoryImpl(dao)
+            val a = repo.addNetwork(root("bnc.example.org", saslUser = "acct"))
+            val b = repo.addNetwork(root("bnc.example.org", saslUser = "acct"))
             assertEquals(a, b)
             assertEquals(1, dao.rows.size)
-            // A different name is a distinct root even with the same saslUser/host.
-            repo.addNetwork(root("Other Bouncer", saslUser = "acct", host = "bnc.example.org"))
+            // A different soju login on the same host is a distinct root.
+            repo.addNetwork(root("bnc.example.org", saslUser = "other"))
             assertEquals(2, dao.rows.size)
         }
 

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/settings/AddNetworkViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/settings/AddNetworkViewModelTest.kt
@@ -223,6 +223,44 @@ class AddNetworkViewModelTest {
         }
 
     @Test
+    fun duplicate_connection_stays_on_form_without_reconnecting() =
+        runTest {
+            val repo = FakeNetworkRepository()
+            repo.networks[42] =
+                NetworkEntity(
+                    id = 42,
+                    name = "Existing",
+                    role = NetworkRole.DIRECT,
+                    host = "irc.libera.chat",
+                    port = 6697,
+                    nick = "me",
+                    username = "me",
+                    realname = "me",
+                )
+            repo.existingResult = 42
+            val connections = FakeConnectionManager()
+            val vm = vm(repo, connections)
+            vm.fillValidDirect()
+            vm.editDisplayName("Different label")
+            var done = false
+
+            vm.submit(onOpenBouncerNetworks = { error("not a bouncer") }, onDone = { done = true })
+            runCurrent()
+
+            assertTrue(vm.state.value.duplicateConnection)
+            assertEquals(AddNetworkPhase.FORM, vm.state.value.phase)
+            assertEquals(null, vm.state.value.networkId)
+            assertTrue(connections.connected.isEmpty())
+            assertFalse(done)
+
+            vm.editAuth(
+                vm.state.value.auth
+                    .copy(serverPassword = "other:secret"),
+            )
+            assertFalse(vm.state.value.duplicateConnection)
+        }
+
+    @Test
     fun soju_missing_password_or_nick_is_not_submittable() =
         runTest {
             val vm = vm(FakeNetworkRepository(), FakeConnectionManager())


### PR DESCRIPTION
## Summary
Discussed in #motd: `networkIdentityKey` matched DIRECT/BOUNCER_ROOT rows on `(host, port, nick, bouncer selector)`. A second account on the same relay (e.g. a WeeChat/CLoak relay using plain `network:password` rather than the `user/network:password` selector format ZNC/CLoak expect) computed an identical key to an already-existing network, so `addNetwork()` silently reused the existing row instead of creating a new one — then reconnected the already-live network and closed the form, with zero feedback that nothing new was created. Repro: add `myweechat.0bin.xyz:1343` as `01_ptirc`, then try adding the same host/port again under a different name — the second add silently did nothing.

- `DIRECT`/`BOUNCER_ROOT` now dedup purely on normalized network **name**. `BOUNCER_CHILD` keeps its `(parentId, bouncerNetId)` key unchanged — that path is soju's internal `LISTNETWORKS` import, not the user-facing "Add network" form, and must stay robust regardless of naming.
- Added `networkNameTaken()` and check it before `addNetwork()`: a colliding name now blocks submission with a visible error (inline under the display-name field, or a banner for the ZNC case where that field is hidden) instead of silently merging.
- The form and every field are left exactly as typed on a name conflict — phase stays `FORM`, nothing navigates away, nothing is lost.
- Rewrote `NetworkDedupTest` for the new semantics: same name now dedups regardless of host/port/nick; a different name on the same host/port/nick now stays distinct (the motivating case).

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.data.repo.* --tests io.github.trevarj.motd.ui.settings.addnetwork.* --tests io.github.trevarj.motd.data.backup.*`
- [x] `./gradlew assembleDebug`
- [x] Verified on-device: added a second network on the same host/port/nick under a different name — now creates a distinct row and connects. Re-adding an existing name now shows the inline error and stays on the form.