### PR TITLE
feat(chat): tint mention bubbles with the warning theme role

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/SendFlight.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/SendFlight.kt
@@ -37,6 +37,7 @@ import io.github.trevarj.motd.ui.components.ReplyPreviewData
 import io.github.trevarj.motd.ui.components.chatBubbleWidth
 import io.github.trevarj.motd.ui.components.messageBubbleRoleColors
 import io.github.trevarj.motd.ui.components.rememberMessageTimeFormatter
+import io.github.trevarj.motd.ui.theme.LocalMotdSemanticColors
 import io.github.trevarj.motd.ui.theme.LocalSpacing
 import io.github.trevarj.motd.ui.theme.MotdMotion
 import kotlin.math.max
@@ -375,6 +376,7 @@ private fun MorphingGhost(
             isSelf = true,
             mentionHighlighted = false,
             kind = MessageKind.PRIVMSG,
+            semantic = LocalMotdSemanticColors.current,
         )
     val fieldInk = MaterialTheme.colorScheme.onSurface
     val plainText = remember(flight.text) { plainIrcText(flight.text) }

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
@@ -84,11 +84,13 @@ import io.github.trevarj.motd.ui.chat.InlineTextSegment
 import io.github.trevarj.motd.ui.chat.extractUrls
 import io.github.trevarj.motd.ui.chat.parseInlineCode
 import io.github.trevarj.motd.ui.theme.LocalLottieMotionEnabled
+import io.github.trevarj.motd.ui.theme.LocalMotdSemanticColors
 import io.github.trevarj.motd.ui.theme.LocalNickColors
 import io.github.trevarj.motd.ui.theme.LocalSpacing
 import io.github.trevarj.motd.ui.theme.LocalTimestampConfig
 import io.github.trevarj.motd.ui.theme.MotdLottieMotion
 import io.github.trevarj.motd.ui.theme.MotdMotion
+import io.github.trevarj.motd.ui.theme.MotdSemanticColors
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import io.github.trevarj.motd.ui.theme.NickColorScheme
 import io.github.trevarj.motd.ui.theme.lottieStrokeColor
@@ -126,12 +128,15 @@ internal fun messageBubbleRoleColors(
     isSelf: Boolean,
     mentionHighlighted: Boolean,
     kind: MessageKind,
+    semantic: MotdSemanticColors,
 ): MessageBubbleRoleColors =
     when {
         mentionHighlighted && !isSelf -> {
+            // The theme's notice/warning role, not a bespoke color: a mention is an attention cue,
+            // and warning already reads that way without success's positive connotation.
             MessageBubbleRoleColors(
-                scheme.secondaryContainer,
-                scheme.onSecondaryContainer,
+                semantic.warningContainer,
+                semantic.onWarningContainer,
             )
         }
 
@@ -262,7 +267,7 @@ fun MessageBubble(
     val mentionHighlighted = hasMention && !isSelf
     val renderedModifier =
         if (mentionHighlighted && kind != MessageKind.ACTION) {
-            modifier.mentionHighlight(accent = MaterialTheme.colorScheme.secondary)
+            modifier.mentionHighlight(accent = LocalMotdSemanticColors.current.warning)
         } else {
             modifier
         }
@@ -418,6 +423,7 @@ fun MessageBubble(
             isSelf,
             mentionHighlighted,
             kind,
+            LocalMotdSemanticColors.current,
         )
     val bubbleColor = bubbleRoles.container
     val textColor = bubbleRoles.content
@@ -643,15 +649,16 @@ private fun ComfortableActionBubble(
     val actionsLabel = stringResource(R.string.chat_bubble_actions)
     val actionDescription = stringResource(R.string.chat_action_message)
     val actionLabel = remember(sender, text) { actionAccessibilityLabel(sender, text) }
+    val semanticColors = LocalMotdSemanticColors.current
     val rowColor =
         if (hasMention) {
-            MaterialTheme.colorScheme.secondaryContainer
+            semanticColors.warningContainer
         } else {
             MaterialTheme.colorScheme.tertiaryContainer
         }
     val bodyColor =
         if (hasMention) {
-            MaterialTheme.colorScheme.onSecondaryContainer
+            semanticColors.onWarningContainer
         } else {
             MaterialTheme.colorScheme.onTertiaryContainer
         }
@@ -871,15 +878,16 @@ private fun ActionMessageRow(
     val actionDescription = stringResource(R.string.chat_action_message)
     val actionLabel = remember(sender, text) { actionAccessibilityLabel(sender, text) }
     val spacing = LocalSpacing.current
+    val semanticColors = LocalMotdSemanticColors.current
     val accent =
         if (hasMention) {
-            MaterialTheme.colorScheme.secondary
+            semanticColors.warning
         } else {
             MaterialTheme.colorScheme.tertiary
         }
     val rowColor =
         if (hasMention) {
-            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = MENTION_ROW_TINT_ALPHA)
+            semanticColors.warningContainer.copy(alpha = MENTION_ROW_TINT_ALPHA)
         } else {
             MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = ACTION_ROW_TINT_ALPHA)
         }
@@ -1191,7 +1199,7 @@ private fun TwoLineMessageRow(
     // behind the whole row so runs of a nick's messages are trackable by speaker.
     val rowTint =
         if (hasMention) {
-            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = MENTION_ROW_TINT_ALPHA)
+            LocalMotdSemanticColors.current.warningContainer.copy(alpha = MENTION_ROW_TINT_ALPHA)
         } else {
             nameColor.copy(alpha = TWO_LINE_ROW_TINT_ALPHA)
         }

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/components/MessageBubbleLayoutTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/components/MessageBubbleLayoutTest.kt
@@ -4,6 +4,7 @@ import io.github.trevarj.motd.data.db.MessageKind
 import io.github.trevarj.motd.data.prefs.TimeFormat
 import io.github.trevarj.motd.ui.theme.MotdLightScheme
 import io.github.trevarj.motd.ui.theme.contrastRatio
+import io.github.trevarj.motd.ui.theme.semanticColors
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -33,12 +34,13 @@ class MessageBubbleLayoutTest {
 
     @Test fun bubbleRoles_areDistinctAndReadable() {
         val scheme = MotdLightScheme
+        val semantic = semanticColors(scheme, dark = false)
         val roles =
             listOf(
-                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = false, MessageKind.PRIVMSG),
-                messageBubbleRoleColors(scheme, isSelf = true, mentionHighlighted = false, MessageKind.PRIVMSG),
-                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = true, MessageKind.PRIVMSG),
-                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = false, MessageKind.NOTICE),
+                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = false, MessageKind.PRIVMSG, semantic),
+                messageBubbleRoleColors(scheme, isSelf = true, mentionHighlighted = false, MessageKind.PRIVMSG, semantic),
+                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = true, MessageKind.PRIVMSG, semantic),
+                messageBubbleRoleColors(scheme, isSelf = false, mentionHighlighted = false, MessageKind.NOTICE, semantic),
             )
 
         assertEquals(4, roles.map { it.container }.distinct().size)


### PR DESCRIPTION
## Summary
Discussed in #motd: a mentioned message today only gets a thin `secondary`-colored side rail plus a subtle `secondaryContainer` bubble tint — easy to miss. trev's direction was to use an existing theme palette role rather than a new bespoke color, so this switches every mention-highlight color site to the existing `warning`/`warningContainer` semantic tokens in `MotdSemanticColors` (already defined, unused in any bubble until now):

- `messageBubbleRoleColors` (the main bubble): `warningContainer`/`onWarningContainer` instead of `secondaryContainer`/`onSecondaryContainer`.
- The side-rail accent (`mentionHighlight`): `warning` instead of `secondary`.
- The comfortable/compact ACTION-message row variants and the two-line dense row wash: same swap.

Amber reads as an attention cue ("you were called out") without a new ad-hoc color, and doesn't collide with self (`primaryContainer`) or NOTICE (`tertiaryContainer`), which already own the other container roles.

`messageBubbleRoleColors` now takes the semantic colors as an explicit parameter so it stays a pure, testable function — the one non-mention call site (`SendFlight`'s outgoing-bubble animation) passes them through unused.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.ui.components.* --tests io.github.trevarj.motd.ui.chat.*` (updated `MessageBubbleLayoutTest` for the new signature)
- [x] `./gradlew assembleDebug`
- [x] Verified on-device: mentioned messages now render with the amber warning tint across the comfortable, compact, and two-line densities.