### PR TITLE
feat(chat): show the sender's own nick on their own bubbles too

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/MessageBubble.kt
@@ -203,9 +203,11 @@ private fun Modifier.mentionHighlight(accent: Color): Modifier =
  * italic no-bubble, plus reply/image/reactions decorations). System-event kinds are rendered by
  * [SystemEventPill] upstream, not here.
  *
- * Grouping: [showSender] draws the nick-colored name + avatar (own messages omit the name). Own
- * bubbles are right-aligned `primaryContainer`; others left `surfaceContainerHigh`. Corner radii
- * tighten on the grouped inner edge.
+ * Grouping: [showSender] draws the nick-colored name on a group's first bubble, own included — a
+ * silent nick change (e.g. an identify failure bouncing you to Guest-1234) belongs on your own
+ * bubble too, not just others'. Only the avatar stays other-senders-only. Own bubbles are
+ * right-aligned `primaryContainer`; others left `surfaceContainerHigh`. Corner radii tighten on
+ * the grouped inner edge.
  */
 internal fun botDisplayName(
     sender: String,
@@ -473,7 +475,9 @@ fun MessageBubble(
                         onLongClickLabel = actionsLabel,
                     ).padding(horizontal = spacing.bubbleInnerHPad, vertical = spacing.bubbleInnerVPad),
         ) {
-            if (showSender && !isSelf) {
+            if (showSender) {
+                // Shown for self too: a nick change (e.g. a silent identify failure bouncing you to
+                // Guest-1234) is exactly the kind of thing your own bubble should surface, not hide.
                 val nameColor = nickColors.nick(sender, MaterialTheme.colorScheme.onSurfaceVariant)
                 Row(
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary
Discussed in #motd: your own current nick isn't guaranteed — a silent identify/SASL failure can bounce you to a server-assigned `Guest-1234`, and until now that change was invisible on your own messages, since \`showSender\` only drew the nick-colored name header for other senders (own messages omitted it, deliberately, per the prior doc comment).

- Drop the `!isSelf` guard so the name renders on the first bubble of your own sequence, same as anyone else's.
- The avatar column stays other-senders-only, unchanged — this PR is nick-only.
- Scoped to the Comfortable bubble layout only. Compact/TwoLine have their own header logic (TwoLine's is already `isSelf`-symmetric, showing name+avatar for everyone). `ComfortableActionBubble` is unaffected — `/me` lines already embed the actor's nick directly in the text regardless of `isSelf`.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDebugUnitTest --tests io.github.trevarj.motd.ui.components.*`
- [x] `./gradlew assembleDebug`
- [x] Verified on-device: own nick now renders above the first bubble of a self-message run, styled identically to other senders' names.

## Screenshot
<img width="1220" height="2712" alt="screenshot_selfnick_20260826-214935" src="https://github.com/user-attachments/assets/ff6f7155-36e1-4c7f-948d-f2527666f218" />
