### PR TITLE
fix(networks): batch reconnect JOINs instead of one command per channel

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
@@ -86,6 +86,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -1728,17 +1729,49 @@ class ConnectionManagerImpl
             }
             // A fresh direct socket has no channel membership. Restore only channels whose durable
             // self JOIN state is still true; explicit PART/KICK rows set joined=false. Bouncer children
-            // remain entirely bouncer-managed.
+            // remain entirely bouncer-managed. Some DIRECT-configured endpoints (a WeeChat relay-irc
+            // listener behind a real ircd session, or any other stateful backend not modeled as a
+            // bouncer role) replay a synthetic self JOIN (+332/353/366) for every already-joined
+            // channel unprompted, right after registration. Give those a short window to arrive and
+            // skip re-JOINing what the server already restored. Whatever's left still needs to go out
+            // as few JOIN lines as possible (comma-separated channel lists, IRC allows this) rather
+            // than one command per channel: an unbatched burst of dozens of JOINs queues up behind a
+            // shared connection's own outbound flood control (observed with WeeChat's relay-irc) and
+            // delays unrelated traffic multiplexed over that same connection for up to a minute.
             if (row.role == NetworkRole.DIRECT) {
-                for (channel in recoveryReader.joinedChannels(row.id)) {
-                    if (!isCurrent()) return
-                    val key = inviteEnrollmentStore.channelKey(row.id, client.isupport.normalize(channel))
-                    client.send(
-                        io.github.trevarj.motd.irc.proto.IrcMessage(
-                            command = "JOIN",
-                            params = listOfNotNull(channel, key),
-                        ),
-                    )
+                val remembered = recoveryReader.joinedChannels(row.id)
+                if (remembered.isNotEmpty()) {
+                    val alreadyReplayed = mutableSetOf<String>()
+                    withTimeoutOrNull(JOIN_REPLAY_SETTLE_TIMEOUT_MS) {
+                        client.broadcastEvents
+                            .filterIsInstance<IrcEvent.Joined>()
+                            .filter { it.isSelf }
+                            .collect { alreadyReplayed += client.isupport.normalize(it.channel) }
+                    }
+                    val toJoin = remembered.filter { client.isupport.normalize(it) !in alreadyReplayed }
+                    val (keyed, keyless) =
+                        toJoin.partition {
+                            inviteEnrollmentStore.channelKey(row.id, client.isupport.normalize(it)) != null
+                        }
+                    for (channel in keyed) {
+                        if (!isCurrent()) return
+                        val key = inviteEnrollmentStore.channelKey(row.id, client.isupport.normalize(channel))
+                        client.send(
+                            io.github.trevarj.motd.irc.proto.IrcMessage(
+                                command = "JOIN",
+                                params = listOfNotNull(channel, key),
+                            ),
+                        )
+                    }
+                    for (batch in keyless.chunked(JOIN_BATCH_SIZE)) {
+                        if (!isCurrent()) return
+                        client.send(
+                            io.github.trevarj.motd.irc.proto.IrcMessage(
+                                command = "JOIN",
+                                params = listOf(batch.joinToString(",")),
+                            ),
+                        )
+                    }
                 }
             }
             if (!isCurrent()) return
@@ -3002,6 +3035,25 @@ internal const val HISTORY_CAP_DECISION_TIMEOUT_MS = 15_000L
  * that never answers its CAP REQ must not be able to hold chat entry for the whole Ready session.
  */
 internal const val READ_MARKER_SETTLE_TIMEOUT_MS = 10_000L
+
+/**
+ * How long a DIRECT-role Ready session waits, right after registration, for the server to replay a
+ * synthetic self JOIN of a remembered channel before falling back to self-JOINing it. Some
+ * DIRECT-configured stateful backends (e.g. WeeChat's relay-irc listener) unconditionally mirror
+ * already-joined channels back to a freshly connecting client without being asked; waiting here
+ * avoids firing a redundant, unpaced JOIN burst that would otherwise queue behind that backend's own
+ * outgoing flood control and delay unrelated traffic sharing the same underlying connection.
+ */
+internal const val JOIN_REPLAY_SETTLE_TIMEOUT_MS = 1_500L
+
+/**
+ * Max channels per batched reconnect JOIN line. IRC allows a comma-separated channel list in one
+ * JOIN command; batching keeps a large remembered-channel set (dozens of channels is common on a
+ * bouncer-backed network) to a handful of commands instead of one per channel, which is what
+ * actually avoids tripping a shared connection's outbound flood control. Conservative relative to
+ * the ~512 byte line limit even for long channel names.
+ */
+internal const val JOIN_BATCH_SIZE = 15
 
 /**
  * One Ready session's entry-gate release: the gate opens only when BOTH hold — the caller decided

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
@@ -1704,7 +1704,7 @@ class ConnectionManagerImpl
             // missing replay events emitted while this method was still doing other suspending work.
             val replayedChannels = mutableSetOf<String>()
             val replayCapture =
-                scope.launch {
+                scope.launch(start = CoroutineStart.UNDISPATCHED) {
                     withTimeoutOrNull(JOIN_REPLAY_SETTLE_TIMEOUT_MS) {
                         client.broadcastEvents
                             .filterIsInstance<IrcEvent.Joined>()

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ConnectionManagerImpl.kt
@@ -1694,6 +1694,24 @@ class ConnectionManagerImpl
             isCurrent: () -> Boolean,
         ) {
             if (!isCurrent()) return
+            // Some DIRECT-configured endpoints (a WeeChat relay-irc listener behind a real ircd
+            // session, or any other stateful backend not modeled as a bouncer role) replay a
+            // synthetic self JOIN (+332/353/366) for every already-joined channel unprompted, right
+            // after registration — sometimes before this method's other Ready-edge work (avatar sync,
+            // MONITOR reconciliation, STS, preset enrollment) has even started. Start listening for
+            // that replay immediately, in parallel with the rest of Ready, and only settle/consume it
+            // right before the recovery JOIN loop below — starting the collector any later risks
+            // missing replay events emitted while this method was still doing other suspending work.
+            val replayedChannels = mutableSetOf<String>()
+            val replayCapture =
+                scope.launch {
+                    withTimeoutOrNull(JOIN_REPLAY_SETTLE_TIMEOUT_MS) {
+                        client.broadcastEvents
+                            .filterIsInstance<IrcEvent.Joined>()
+                            .filter { it.isSelf }
+                            .collect { replayedChannels += client.isupport.normalize(it.channel) }
+                    }
+                }
             avatarCoordinator.onReady(row.id, client)
             if (!isCurrent()) return
             reconcileMonitor(
@@ -1729,26 +1747,17 @@ class ConnectionManagerImpl
             }
             // A fresh direct socket has no channel membership. Restore only channels whose durable
             // self JOIN state is still true; explicit PART/KICK rows set joined=false. Bouncer children
-            // remain entirely bouncer-managed. Some DIRECT-configured endpoints (a WeeChat relay-irc
-            // listener behind a real ircd session, or any other stateful backend not modeled as a
-            // bouncer role) replay a synthetic self JOIN (+332/353/366) for every already-joined
-            // channel unprompted, right after registration. Give those a short window to arrive and
-            // skip re-JOINing what the server already restored. Whatever's left still needs to go out
-            // as few JOIN lines as possible (comma-separated channel lists, IRC allows this) rather
-            // than one command per channel: an unbatched burst of dozens of JOINs queues up behind a
-            // shared connection's own outbound flood control (observed with WeeChat's relay-irc) and
-            // delays unrelated traffic multiplexed over that same connection for up to a minute.
+            // remain entirely bouncer-managed. Skip re-JOINing whatever the server already replayed
+            // (captured above) and send the rest as few JOIN lines as possible (comma-separated
+            // channel lists, IRC allows this) rather than one command per channel: an unbatched burst
+            // of dozens of JOINs queues up behind a shared connection's own outbound flood control
+            // (observed with WeeChat's relay-irc) and delays unrelated traffic multiplexed over that
+            // same connection for up to a minute.
             if (row.role == NetworkRole.DIRECT) {
                 val remembered = recoveryReader.joinedChannels(row.id)
                 if (remembered.isNotEmpty()) {
-                    val alreadyReplayed = mutableSetOf<String>()
-                    withTimeoutOrNull(JOIN_REPLAY_SETTLE_TIMEOUT_MS) {
-                        client.broadcastEvents
-                            .filterIsInstance<IrcEvent.Joined>()
-                            .filter { it.isSelf }
-                            .collect { alreadyReplayed += client.isupport.normalize(it.channel) }
-                    }
-                    val toJoin = remembered.filter { client.isupport.normalize(it) !in alreadyReplayed }
+                    replayCapture.join()
+                    val toJoin = channelsNeedingJoin(remembered, replayedChannels, client.isupport::normalize)
                     val (keyed, keyless) =
                         toJoin.partition {
                             inviteEnrollmentStore.channelKey(row.id, client.isupport.normalize(it)) != null
@@ -1763,7 +1772,7 @@ class ConnectionManagerImpl
                             ),
                         )
                     }
-                    for (batch in keyless.chunked(JOIN_BATCH_SIZE)) {
+                    for (batch in chunkChannelsForJoin(keyless)) {
                         if (!isCurrent()) return
                         client.send(
                             io.github.trevarj.motd.irc.proto.IrcMessage(
@@ -1772,7 +1781,11 @@ class ConnectionManagerImpl
                             ),
                         )
                     }
+                } else {
+                    replayCapture.cancel()
                 }
+            } else {
+                replayCapture.cancel()
             }
             if (!isCurrent()) return
             // A bound soju child becomes Ready before its post-bind feature CAP ACKs. Keep these
@@ -3047,13 +3060,50 @@ internal const val READ_MARKER_SETTLE_TIMEOUT_MS = 10_000L
 internal const val JOIN_REPLAY_SETTLE_TIMEOUT_MS = 1_500L
 
 /**
- * Max channels per batched reconnect JOIN line. IRC allows a comma-separated channel list in one
- * JOIN command; batching keeps a large remembered-channel set (dozens of channels is common on a
- * bouncer-backed network) to a handful of commands instead of one per channel, which is what
- * actually avoids tripping a shared connection's outbound flood control. Conservative relative to
- * the ~512 byte line limit even for long channel names.
+ * Which of [remembered] still need a self-JOIN: those the server did NOT already replay (per
+ * [replayedNormalized], a set of channel names normalized the same way as [remembered] via
+ * [normalize]) during the settle window.
  */
-internal const val JOIN_BATCH_SIZE = 15
+internal fun channelsNeedingJoin(
+    remembered: List<String>,
+    replayedNormalized: Set<String>,
+    normalize: (String) -> String,
+): List<String> = remembered.filter { normalize(it) !in replayedNormalized }
+
+/**
+ * Byte budget for one batched reconnect JOIN line's channel-list param, leaving room for the
+ * `JOIN ` command word and the trailing CRLF within [IrcMessage]'s 512-byte wire limit. A fixed
+ * channel-count batch size can't guarantee this: e.g. 15 legal 50-byte channel names would already
+ * overflow 512 bytes on their own, and [IrcMessage.serialize] throws rather than truncate — so
+ * batches must be sized by actual UTF-8 byte length, not channel count.
+ */
+private const val JOIN_LINE_BUDGET_BYTES = 500
+
+/**
+ * Greedily groups [channels] into comma-joined batches (IRC allows a channel list in one JOIN
+ * command) that each fit [JOIN_LINE_BUDGET_BYTES], accounting for the comma separators added by
+ * `joinToString(",")`. A single channel name that alone exceeds the budget still gets its own
+ * batch — [IrcMessage.serialize] is the final arbiter and will reject it if truly unsendable.
+ */
+internal fun chunkChannelsForJoin(channels: List<String>): List<List<String>> {
+    val batches = mutableListOf<List<String>>()
+    var current = mutableListOf<String>()
+    var currentBytes = 0
+    for (channel in channels) {
+        val channelBytes = channel.toByteArray(Charsets.UTF_8).size
+        val separatorBytesIfAppended = if (current.isEmpty()) 0 else 1
+        if (current.isNotEmpty() && currentBytes + separatorBytesIfAppended + channelBytes > JOIN_LINE_BUDGET_BYTES) {
+            batches += current
+            current = mutableListOf()
+            currentBytes = 0
+        }
+        val separatorBytes = if (current.isEmpty()) 0 else 1
+        current += channel
+        currentBytes += separatorBytes + channelBytes
+    }
+    if (current.isNotEmpty()) batches += current
+    return batches
+}
 
 /**
  * One Ready session's entry-gate release: the gate opens only when BOTH hold — the caller decided

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/ReconnectJoinBatchingTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/ReconnectJoinBatchingTest.kt
@@ -1,0 +1,91 @@
+package io.github.trevarj.motd.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReconnectJoinBatchingTest {
+    @Test
+    fun `channels already replayed by the server are excluded`() {
+        val toJoin =
+            channelsNeedingJoin(
+                remembered = listOf("#a", "#b", "#c"),
+                replayedNormalized = setOf("#a", "#c"),
+                normalize = { it },
+            )
+
+        assertEquals(listOf("#b"), toJoin)
+    }
+
+    @Test
+    fun `normalization is applied before comparing against the replayed set`() {
+        val toJoin =
+            channelsNeedingJoin(
+                remembered = listOf("#Libera", "#other"),
+                replayedNormalized = setOf("#libera"),
+                normalize = { it.lowercase() },
+            )
+
+        assertEquals(listOf("#other"), toJoin)
+    }
+
+    @Test
+    fun `nothing replayed means every remembered channel still needs a self JOIN`() {
+        val toJoin = channelsNeedingJoin(listOf("#a", "#b"), emptySet()) { it }
+
+        assertEquals(listOf("#a", "#b"), toJoin)
+    }
+
+    @Test
+    fun `everything replayed means nothing needs a self JOIN`() {
+        val toJoin = channelsNeedingJoin(listOf("#a", "#b"), setOf("#a", "#b")) { it }
+
+        assertTrue(toJoin.isEmpty())
+    }
+
+    @Test
+    fun `a handful of short channel names fit in one batch`() {
+        val batches = chunkChannelsForJoin(listOf("#a", "#b", "#c"))
+
+        assertEquals(listOf(listOf("#a", "#b", "#c")), batches)
+    }
+
+    @Test
+    fun `fifteen legal 50-byte channel names do not fit one wire-safe batch`() {
+        // Reproduces the exact scenario the fixed-count JOIN_BATCH_SIZE = 15 batching missed: 15
+        // legal 50-byte channel names produce a ~771-byte JOIN line, over IrcMessage's 512-byte
+        // limit. Byte-budget batching must split this into more than one line.
+        val channels = (1..15).map { "#" + "a".repeat(49) }
+
+        val batches = chunkChannelsForJoin(channels)
+
+        assertTrue("expected more than one batch, got ${batches.size}", batches.size > 1)
+        for (batch in batches) {
+            val lineBytes = batch.joinToString(",").toByteArray(Charsets.UTF_8).size
+            assertTrue("batch line was $lineBytes bytes: $batch", lineBytes <= 500)
+        }
+    }
+
+    @Test
+    fun `every remembered channel appears exactly once across all batches`() {
+        val channels = (1..40).map { "#channel$it" }
+
+        val batches = chunkChannelsForJoin(channels)
+
+        assertEquals(channels, batches.flatten())
+    }
+
+    @Test
+    fun `empty input produces no batches`() {
+        assertTrue(chunkChannelsForJoin(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `a single channel name longer than the budget still gets its own batch`() {
+        val hugeChannel = "#" + "x".repeat(600)
+
+        val batches = chunkChannelsForJoin(listOf(hugeChannel, "#normal"))
+
+        assertEquals(listOf(listOf(hugeChannel), listOf("#normal")), batches)
+    }
+}


### PR DESCRIPTION
## Problem

On a `DIRECT`-role reconnect, motd fires one `JOIN` command per remembered
channel with no batching or pacing. Against a shared connection with a lot
of channels (a WeeChat `relay-irc` listener sharing one underlying IRC
connection across multiple clients, for example), an unpaced burst of
dozens of `JOIN`s trips the backend's outbound flood control — which
delays *unrelated* traffic multiplexed over that same connection.

Repro'd with a real setup: WeeChat core with both weechat-relay (for
weechat-android) and a relay-irc listener (for motd) pointed at the same
IRC session. Connecting motd caused a message sent from weechat-android
right after to take up to ~60s to actually reach the network — traced via
logcat to motd blasting 65 and 32 unbatched `JOIN` lines in under 400ms
across two networks on reconnect.

## Fix

- Give the server a short window (1.5s) after registration to replay
  already-joined channels itself — some stateful `DIRECT`-configured
  backends do this unprompted (WeeChat's `relay-irc` always does, for
  every channel, right after the welcome numerics) — and skip re-JOINing
  those.
- Batch whatever channels are left into comma-separated `JOIN` lines
  (IRC allows a channel list in one command) instead of one command per
  channel, capped at `JOIN_BATCH_SIZE` (15) channels per line. Keyed
  channels are still sent individually since a batched line needs a
  positionally-aligned key list.

Verified on-device against the exact repro above: after this change, the
same reconnect no longer produces a noticeable delay in messages sent by
another client sharing the connection.

## Test plan

- [x] `ktlintCheck`
- [x] `assembleDebug`
- [x] Manual on-device repro: reconnect motd against WeeChat (relay-irc +
      weechat-android on the same core), send from weechat-android
      immediately after — no delay, versus ~60s before this change.