### PR TITLE
feat(search): smart search buffer matches

### DIFF
--- a/app/src/androidTest/kotlin/io/github/trevarj/motd/ui/search/SearchScreenUiTest.kt
+++ b/app/src/androidTest/kotlin/io/github/trevarj/motd/ui/search/SearchScreenUiTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MessageEntity
 import io.github.trevarj.motd.data.db.MessageKind
 import io.github.trevarj.motd.data.db.SearchHit
@@ -65,6 +66,9 @@ class SearchScreenUiTest {
             bufferId = hit.message.bufferId,
             bufferDisplayName = "#kotlin",
             networkName = "Libera",
+            bufferType = BufferType.CHANNEL,
+            networkId = 1,
+            avatarOverrideModel = null,
             hits = listOf(hit),
         )
 
@@ -86,5 +90,7 @@ class SearchScreenUiTest {
             ),
         bufferDisplayName = "#kotlin",
         networkName = "Libera",
+        bufferType = BufferType.CHANNEL,
+        networkId = 1,
     )
 }

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
@@ -1528,6 +1528,7 @@ interface MessageDao {
     @Query(
         """
         SELECT m.*, b.displayName AS bufferDisplayName, n.name AS networkName,
+               b.type AS bufferType, b.networkId AS networkId, b.avatarOverrideModel AS avatarOverrideModel,
                ni.caseMapping AS caseMapping, ni.chanTypes AS chanTypes
         FROM messages m
         JOIN messages_fts f ON m.id = f.rowid
@@ -1558,6 +1559,9 @@ data class SearchHit(
     @Embedded val message: MessageEntity,
     val bufferDisplayName: String,
     val networkName: String,
+    val bufferType: BufferType,
+    val networkId: Long,
+    val avatarOverrideModel: String? = null,
     val caseMapping: String? = null,
     val chanTypes: String? = null,
 )

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchScreen.kt
@@ -6,14 +6,19 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.KeyboardActions
@@ -43,8 +48,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -53,22 +60,30 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.trevarj.motd.R
+import io.github.trevarj.motd.data.db.BufferType
+import io.github.trevarj.motd.data.db.ChatListRow
 import io.github.trevarj.motd.data.db.MessageEntity
 import io.github.trevarj.motd.data.db.MessageKind
 import io.github.trevarj.motd.data.db.SearchHit
 import io.github.trevarj.motd.data.prefs.TimeFormat
 import io.github.trevarj.motd.data.repo.SearchCoverage
 import io.github.trevarj.motd.ui.chatlist.relativeChatTime
+import io.github.trevarj.motd.ui.components.Avatar
 import io.github.trevarj.motd.ui.components.EmptyState
+import io.github.trevarj.motd.ui.components.NetworkChip
 import io.github.trevarj.motd.ui.components.rememberMessageTimeFormatter
 import io.github.trevarj.motd.ui.components.resolveIs24Hour
+import io.github.trevarj.motd.ui.theme.LocalMotdSemanticColors
+import io.github.trevarj.motd.ui.theme.LocalNickColors
 import io.github.trevarj.motd.ui.theme.LocalTimestampConfig
 import io.github.trevarj.motd.ui.theme.MotdMotion
+import io.github.trevarj.motd.ui.theme.MotdShapes
 import io.github.trevarj.motd.ui.theme.MotdTheme
 
 /** Stateful entry: wires the ViewModel, applies the nav buffer scope, drives navigation. */
@@ -103,6 +118,9 @@ fun SearchScreen(
             )
         },
         onOpenServerHit = { hit -> onOpenHit(hit.bufferId, hit.msgid, hit.serverTime, null) },
+        // A name match carries no message target — same "open the buffer, no jump" shape as a
+        // server hit missing both a time and an id would need, just without that ever happening.
+        onOpenBufferMatch = { bufferId -> onOpenHit(bufferId, null, 0L, null) },
     )
 }
 
@@ -116,6 +134,7 @@ fun SearchContent(
     onOpenHit: (SearchHit) -> Unit,
     onServerSearchSubmit: () -> Unit = {},
     onOpenServerHit: (ServerHitUi) -> Unit = {},
+    onOpenBufferMatch: (Long) -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
@@ -295,10 +314,12 @@ fun SearchContent(
 
                     SearchPane.RESULTS -> {
                         SearchResults(
+                            bufferMatches = visibleState.bufferMatches,
                             groups = visibleState.groups,
                             query = parseSearchQuery(visibleState.rawQuery).text,
                             truncated = visibleState.truncated,
                             onOpenHit = onOpenHit,
+                            onOpenBufferMatch = onOpenBufferMatch,
                         )
                     }
                 }
@@ -319,7 +340,7 @@ private fun searchPane(state: SearchUiState): SearchPane =
         state.scope == SearchScope.SERVER -> SearchPane.SERVER
         state.rawQuery.isBlank() -> SearchPane.PROMPT
         state.searching -> SearchPane.SEARCHING
-        state.groups.isEmpty() -> SearchPane.NO_RESULTS
+        state.groups.isEmpty() && state.bufferMatches.isEmpty() -> SearchPane.NO_RESULTS
         else -> SearchPane.RESULTS
     }
 
@@ -354,21 +375,66 @@ private fun emptyMessage(state: SearchUiState): Int =
 
 @Composable
 private fun SearchResults(
+    bufferMatches: List<ChatListRow>,
     groups: List<SearchGroup>,
     query: String,
     truncated: Boolean,
     onOpenHit: (SearchHit) -> Unit,
+    onOpenBufferMatch: (Long) -> Unit = {},
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize().testTag("search_results")) {
-        groups.forEach { group ->
-            item(key = "h-${group.bufferId}") {
+        if (bufferMatches.isNotEmpty()) {
+            item(key = "buffer_matches_header") {
                 Text(
-                    text = "${group.bufferDisplayName} · ${group.networkName}",
+                    text = stringResource(R.string.search_section_buffers),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
                 )
+            }
+            item(key = "buffer_matches_row") {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth().testTag("search_buffer_matches"),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                ) {
+                    items(bufferMatches, key = { it.bufferId }) { row ->
+                        BufferMatchChip(row = row, onClick = { onOpenBufferMatch(row.bufferId) })
+                    }
+                }
+            }
+        }
+        groups.forEach { group ->
+            stickyHeader(key = "h-${group.bufferId}") {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
+                ) {
+                    Avatar(
+                        name = group.bufferDisplayName,
+                        isChannel = group.bufferType == BufferType.CHANNEL,
+                        networkId = group.networkId,
+                        conversationModel = group.avatarOverrideModel,
+                        size = 20.dp,
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = group.bufferDisplayName,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    NetworkChip(name = group.networkName, dimmed = true)
+                }
             }
             items(group.hits, key = { it.message.id }) { hit ->
                 SearchHitRow(hit = hit, query = query, onClick = { onOpenHit(hit) })
@@ -390,6 +456,42 @@ private fun SearchResults(
     }
 }
 
+/** One name match in the "smart" row: avatar plus a two-line label (room name, then network). */
+@Composable
+private fun BufferMatchChip(
+    row: ChatListRow,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .width(72.dp)
+                .clickable(onClick = onClick)
+                .testTag("search_buffer_match_${row.bufferId}"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Avatar(
+            name = row.displayName,
+            isChannel = row.type == BufferType.CHANNEL,
+            networkId = row.networkId,
+            conversationModel = row.avatarOverrideModel,
+            size = 48.dp,
+        )
+        Text(
+            text = row.displayName,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        NetworkChip(
+            name = row.networkName,
+            dimmed = true,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+    }
+}
+
 @Composable
 private fun SearchHitRow(
     hit: SearchHit,
@@ -402,6 +504,7 @@ private fun SearchHitRow(
     query = query,
     // Per-hit handle (sender+text can repeat); msgid when present, else the local row id.
     tag = "search_result_${hit.message.msgid ?: hit.message.id}",
+    networkId = hit.networkId,
     onClick = onClick,
 )
 
@@ -416,6 +519,7 @@ private fun ServerHitRow(
     serverTime = hit.serverTime,
     query = query,
     tag = "search_result_${hit.msgid ?: hit.serverTime}",
+    networkId = null,
     onClick = onClick,
 )
 
@@ -427,6 +531,7 @@ private fun SearchRow(
     serverTime: Long,
     query: String,
     tag: String,
+    networkId: Long?,
     onClick: () -> Unit,
 ) {
     // Search results always show a time, independent of the in-chat "show timestamps" toggle.
@@ -441,19 +546,31 @@ private fun SearchRow(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp)
+                .clip(MotdShapes.card)
+                .background(MaterialTheme.colorScheme.surfaceContainerLow)
                 .testTag(tag)
                 .clickable(onClick = onClick)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        Avatar(
+            name = sender,
+            networkId = networkId,
+            // Matched to labelMedium's line height so the avatar reads as part of the nick line,
+            // not as its own bigger element.
+            size = 16.dp,
+            modifier = Modifier.align(Alignment.Top),
+        )
         Column(modifier = Modifier.weight(1f)) {
+            val nickColors = LocalNickColors.current
             Text(
                 text = sender,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = nickColors.nick(sender, MaterialTheme.colorScheme.onSurfaceVariant),
             )
             Text(
-                text = highlightSnippet(text, query),
+                text = highlightSnippet(text, query, LocalMotdSemanticColors.current.warningContainer),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 3,
             )
@@ -571,10 +688,11 @@ private fun ServerSearchSection(
     }
 }
 
-/** Bold every case-insensitive occurrence of [query]'s terms in [text]. */
+/** Bold and highlight every case-insensitive occurrence of [query]'s terms in [text]. */
 private fun highlightSnippet(
     text: String,
     query: String,
+    highlightColor: Color,
 ): AnnotatedString {
     val terms = query.split(Regex("\\s+")).map { it.trim() }.filter { it.length >= 2 }
     if (terms.isEmpty()) return AnnotatedString(text)
@@ -585,7 +703,11 @@ private fun highlightSnippet(
             val t = term.lowercase()
             var idx = lower.indexOf(t)
             while (idx >= 0) {
-                addStyle(SpanStyle(fontWeight = FontWeight.Bold), idx, idx + term.length)
+                addStyle(
+                    SpanStyle(fontWeight = FontWeight.Bold, background = highlightColor),
+                    idx,
+                    idx + term.length,
+                )
                 idx = lower.indexOf(t, idx + term.length)
             }
         }
@@ -608,6 +730,9 @@ private fun SearchContentPreview() {
                                 bufferId = 1,
                                 bufferDisplayName = "#kotlin",
                                 networkName = "Libera",
+                                bufferType = BufferType.CHANNEL,
+                                networkId = 1,
+                                avatarOverrideModel = null,
                                 hits =
                                     listOf(
                                         SearchHit(
@@ -623,6 +748,8 @@ private fun SearchContentPreview() {
                                                 ),
                                             bufferDisplayName = "#kotlin",
                                             networkName = "Libera",
+                                            bufferType = BufferType.CHANNEL,
+                                            networkId = 1,
                                         ),
                                     ),
                             ),

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchViewModel.kt
@@ -345,20 +345,27 @@ class SearchViewModel
         // Independent of the debounced local FTS pipeline above: the "smart" row is a name filter
         // over an already-loaded list, not a query, so there is no reason to make it wait.
         @OptIn(ExperimentalCoroutinesApi::class)
-        private val bufferMatches: Flow<List<ChatListRow>> =
+        private val bufferMatches: Flow<Pair<SearchKey, List<ChatListRow>>> =
             searchKey.flatMapLatest { key ->
                 val parsed = parseSearchQuery(key.rawQuery)
                 if (key.scope != SearchScope.ALL || parsed.text.isBlank()) {
-                    flowOf(emptyList())
+                    flowOf(key to emptyList())
                 } else {
-                    bufferRepository.observeChatList().map { rows -> matchingBufferRows(rows, parsed.text) }
+                    bufferRepository.observeChatList().map { rows -> key to matchingBufferRows(rows, parsed.text) }
                 }
             }
 
         val state: StateFlow<SearchUiState> =
-            combine(localState, serverSection, bufferMatches) { local, server, matches ->
+            combine(localState, serverSection, bufferMatches) { local, server, (matchKey, matches) ->
                 local.copy(
-                    bufferMatches = matches,
+                    // Independent keyed flows can arrive in either order. Never pair a new query or
+                    // scope with name matches produced for the previous one.
+                    bufferMatches =
+                        if (matchKey.rawQuery == local.rawQuery && matchKey.scope == local.scope) {
+                            matches
+                        } else {
+                            emptyList()
+                        },
                     serverSearchAvailable = server.available,
                     // Leaving the server scope is two writes — the key, then the cancel — and they
                     // reach this combine separately, so a state pairing a local scope with the

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/search/SearchViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.trevarj.motd.data.db.BufferEntity
 import io.github.trevarj.motd.data.db.BufferType
+import io.github.trevarj.motd.data.db.ChatListRow
 import io.github.trevarj.motd.data.db.SearchHit
 import io.github.trevarj.motd.data.repo.BufferRepository
 import io.github.trevarj.motd.data.repo.SearchCoverage
@@ -75,6 +76,9 @@ data class SearchGroup(
     val bufferId: Long,
     val bufferDisplayName: String,
     val networkName: String,
+    val bufferType: BufferType,
+    val networkId: Long,
+    val avatarOverrideModel: String?,
     val hits: List<SearchHit>,
 )
 
@@ -83,6 +87,13 @@ data class SearchUiState(
     val scope: SearchScope = SearchScope.ALL,
     /** True when this screen was launched scoped to a buffer (enables the "current" chip). */
     val hasBufferScope: Boolean = false,
+    /**
+     * Channel/DM name matches ("smart" results): shown as a row above the message-content groups
+     * below, so a query matching a room's name surfaces it even when no message matches. Populated
+     * only for [SearchScope.ALL] — a buffer- or server-scoped search is already about message
+     * content within one target, not room discovery.
+     */
+    val bufferMatches: List<ChatListRow> = emptyList(),
     val groups: List<SearchGroup> = emptyList(),
     val searching: Boolean = false,
     /** What the searched corpus covers for the active scope; null until the first emission. */
@@ -331,9 +342,23 @@ class SearchViewModel
                     }
                 }
 
+        // Independent of the debounced local FTS pipeline above: the "smart" row is a name filter
+        // over an already-loaded list, not a query, so there is no reason to make it wait.
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private val bufferMatches: Flow<List<ChatListRow>> =
+            searchKey.flatMapLatest { key ->
+                val parsed = parseSearchQuery(key.rawQuery)
+                if (key.scope != SearchScope.ALL || parsed.text.isBlank()) {
+                    flowOf(emptyList())
+                } else {
+                    bufferRepository.observeChatList().map { rows -> matchingBufferRows(rows, parsed.text) }
+                }
+            }
+
         val state: StateFlow<SearchUiState> =
-            combine(localState, serverSection) { local, server ->
+            combine(localState, serverSection, bufferMatches) { local, server, matches ->
                 local.copy(
+                    bufferMatches = matches,
                     serverSearchAvailable = server.available,
                     // Leaving the server scope is two writes — the key, then the cancel — and they
                     // reach this combine separately, so a state pairing a local scope with the
@@ -366,6 +391,29 @@ class SearchViewModel
         }
     }
 
+/** Cap on the "smart" channel/DM match row: a handful of best fits, not a second results list. */
+internal const val BUFFER_MATCH_LIMIT = 5
+
+/**
+ * Room-name matches for the "smart" results row: non-archived, non-server rows whose display name
+ * contains [query] (case-insensitive substring — this is name matching, not FTS). Pure and ordered
+ * by the chat list's own order (already pinned/recency-sorted), so no extra ranking logic is needed
+ * here.
+ */
+internal fun matchingBufferRows(
+    rows: List<ChatListRow>,
+    query: String,
+    limit: Int = BUFFER_MATCH_LIMIT,
+): List<ChatListRow> {
+    if (query.isBlank()) return emptyList()
+    return rows
+        .asSequence()
+        .filter { it.type != BufferType.SERVER && !it.archived }
+        .filter { it.displayName.contains(query, ignoreCase = true) }
+        .take(limit)
+        .toList()
+}
+
 /** Group hits by buffer, preserving overall recency order (hits already time-ordered by DAO). */
 fun groupHits(hits: List<SearchHit>): List<SearchGroup> =
     hits
@@ -376,6 +424,9 @@ fun groupHits(hits: List<SearchHit>): List<SearchGroup> =
                 bufferId = bufferId,
                 bufferDisplayName = first.bufferDisplayName,
                 networkName = first.networkName,
+                bufferType = first.bufferType,
+                networkId = first.networkId,
+                avatarOverrideModel = first.avatarOverrideModel,
                 hits = groupHits,
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,7 @@
     <string name="search_server_truncated">The server limits results to 100 matches. Narrow the query to see the rest.</string>
     <string name="search_prompt_title">Search your history</string>
     <string name="search_prompt_message">Type to search. Use from:nick to filter by sender.</string>
+    <string name="search_section_buffers">Channels &amp; DMs</string>
 
     <!-- Channel info (WP8) -->
     <string name="channelinfo_title">Channel info</string>

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/search/SearchViewModelTest.kt
@@ -87,6 +87,8 @@ class SearchViewModelTest {
             ),
         bufferDisplayName = "#kotlin",
         networkName = "Libera",
+        bufferType = BufferType.CHANNEL,
+        networkId = 1,
     )
 
     /** Counts search() invocations so we can assert the debounce collapses rapid keystrokes. */
@@ -156,12 +158,35 @@ class SearchViewModelTest {
         type = type,
     )
 
+    private fun chatListRow(
+        bufferId: Long,
+        displayName: String,
+        type: BufferType = BufferType.CHANNEL,
+        archived: Boolean = false,
+        networkName: String = "Libera",
+    ) = ChatListRow(
+        bufferId = bufferId,
+        networkId = NETWORK_ID,
+        networkName = networkName,
+        displayName = displayName,
+        type = type,
+        pinned = false,
+        muted = false,
+        lastMessageText = null,
+        lastMessageSender = null,
+        lastMessageTime = null,
+        unreadCount = 0,
+        mentionCount = 0,
+        archived = archived,
+    )
+
     private class FakeBufferRepository(
         initial: BufferEntity? = null,
+        private val chatList: List<ChatListRow> = emptyList(),
     ) : BufferRepository {
         val buffers = MutableStateFlow(initial)
 
-        override fun observeChatList(): Flow<List<ChatListRow>> = flowOf(emptyList())
+        override fun observeChatList(): Flow<List<ChatListRow>> = flowOf(chatList)
 
         override fun observeBuffer(id: Long): Flow<BufferEntity?> = buffers
 
@@ -810,6 +835,58 @@ class SearchViewModelTest {
                 repo.emit("alpha", null, listOf(hit(1, "late alpha result")))
                 runCurrent()
                 expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun matchingBufferRows_matches_displayName_case_insensitively_and_respects_the_limit() {
+        val rows =
+            listOf(
+                chatListRow(1, "#MotdChat"),
+                chatListRow(2, "#other"),
+                chatListRow(3, "motd-fan (DM)", type = BufferType.QUERY),
+                chatListRow(4, "#motd-archived", archived = true),
+                chatListRow(5, "Server", type = BufferType.SERVER),
+            )
+
+        val matches = matchingBufferRows(rows, "motd")
+
+        assertEquals(listOf(1L, 3L), matches.map(ChatListRow::bufferId))
+    }
+
+    @Test
+    fun matchingBufferRows_blank_query_matches_nothing() {
+        assertEquals(emptyList<ChatListRow>(), matchingBufferRows(listOf(chatListRow(1, "#motd")), " "))
+    }
+
+    @Test
+    fun matchingBufferRows_is_capped_at_the_limit() {
+        val rows = (1..10).map { chatListRow(it.toLong(), "#motd-$it") }
+
+        assertEquals(BUFFER_MATCH_LIMIT, matchingBufferRows(rows, "motd").size)
+    }
+
+    @Test
+    fun buffer_matches_populate_only_for_the_all_scope() =
+        runTest {
+            val repo = ControlledSearchRepository()
+            repo.emit("motd", null, emptyList())
+            val buffers = FakeBufferRepository(chatList = listOf(chatListRow(9, "#motd")))
+            val vm = viewModel(repo, buffers = buffers)
+
+            vm.state.test {
+                awaitItem()
+                vm.onQueryChange("motd")
+                runCurrent()
+                advanceTimeBy(250)
+                runCurrent()
+                val allScope = awaitStateWhere { it.bufferMatches.isNotEmpty() }
+                assertEquals(listOf(9L), allScope.bufferMatches.map(ChatListRow::bufferId))
+
+                vm.onScopeChange(SearchScope.SERVER)
+                runCurrent()
+                assertEquals(emptyList<ChatListRow>(), awaitStateWhere { it.scope == SearchScope.SERVER }.bufferMatches)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
## Summary

Adds a "Channels & DMs" row to search results: room-name matches (case-insensitive
substring on display name) shown above the message-content groups, so a query
matching a room's name surfaces it even when no message matches.

- Buffer-match chips and message-hit group headers reuse the same network-name
  pill (`NetworkChip`) already used in the merged chat list, plus a small avatar
  for the channel/DM.
- Matched query terms inside message snippets get a themed highlight (background
  = the `warning` semantic container) in addition to bold.
- Each message hit renders as its own card (matching the chat list's card look),
  with a small per-sender avatar next to the nick, colored via the app's normal
  nick-coloring scheme (`LocalNickColors`).
- Group headers are sticky (`LazyListScope.stickyHeader`), so scrolling a long
  result list never loses track of which channel/DM the visible cards belong to.

Iterated on with the maintainer over a few rounds of visual feedback (pill reuse,
highlight color, avatars, card styling, sticky headers).

**Depends on #76** — this branch is stacked on `fix/reconnect-join-batching` since
both were being tested together on-device; the diff here will shrink to just the
search changes once #76 merges.

## Test plan

- [x] `ktlintCheck`
- [x] `testDebugUnitTest` (search-scoped)
- [x] `assembleDebug`
- [x] Manual on-device verification of each visual iteration (pill, highlight,
      avatars, card, sticky header)