### PR TITLE
feat(notify): watch a channel for all messages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,13 @@ flowchart TD
 - The app ships as a single Google-free build with no product flavors; push
   delivery is UnifiedPush only. The E2E build is x86_64-compatible and
   intentionally omits the arm64-only libbox JNI.
+- Channel watch follows one canonical channel across redirects until its saved
+  deadline (or until stopped). It admits live PRIVMSG/ACTION notifications and
+  overrides mute, including already-qualifying push mentions; it does not request
+  additional push deliveries or notify for history/replay. Self, ignore, fool,
+  foreground, and read suppression remain. Original watch eligibility is stored
+  with each event so interrupted notification recovery stays silent and does not
+  reinterpret old messages using a later watch.
 
 ## Where to work
 

--- a/app/schemas/io.github.trevarj.motd.data.db.MotdDatabase/39.json
+++ b/app/schemas/io.github.trevarj.motd.data.db.MotdDatabase/39.json
@@ -1,0 +1,2203 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 39,
+    "identityHash": "46d56ef824f2ea62549d1429794c1621",
+    "entities": [
+      {
+        "tableName": "networks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `role` TEXT NOT NULL, `parentId` INTEGER, `bouncerNetId` TEXT, `host` TEXT NOT NULL, `port` INTEGER NOT NULL, `tls` INTEGER NOT NULL, `nick` TEXT NOT NULL, `username` TEXT NOT NULL, `realname` TEXT NOT NULL, `saslMechanism` TEXT NOT NULL, `saslUser` TEXT, `saslPassword` TEXT, `serverPassword` TEXT, `nickServPassword` TEXT, `nickServIdentifySyntax` TEXT, `nickServRecoveryEnabled` INTEGER NOT NULL DEFAULT 0, `nickServRecoverySequence` TEXT, `initialAwayMessage` TEXT, `clientCertAlias` TEXT, `autoConnect` INTEGER NOT NULL, `ordering` INTEGER NOT NULL, `wsUrl` TEXT, `obfsMode` TEXT, `proxyHost` TEXT, `proxyPort` INTEGER, `obfsLink` TEXT, `pendingCredentialRequirements` TEXT, `restoreAutoConnect` INTEGER NOT NULL, `serverIconUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bouncerNetId",
+            "columnName": "bouncerNetId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tls",
+            "columnName": "tls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nick",
+            "columnName": "nick",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "realname",
+            "columnName": "realname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saslMechanism",
+            "columnName": "saslMechanism",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saslUser",
+            "columnName": "saslUser",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "saslPassword",
+            "columnName": "saslPassword",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverPassword",
+            "columnName": "serverPassword",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickServPassword",
+            "columnName": "nickServPassword",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickServIdentifySyntax",
+            "columnName": "nickServIdentifySyntax",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nickServRecoveryEnabled",
+            "columnName": "nickServRecoveryEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "nickServRecoverySequence",
+            "columnName": "nickServRecoverySequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "initialAwayMessage",
+            "columnName": "initialAwayMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clientCertAlias",
+            "columnName": "clientCertAlias",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "autoConnect",
+            "columnName": "autoConnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wsUrl",
+            "columnName": "wsUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "obfsMode",
+            "columnName": "obfsMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proxyHost",
+            "columnName": "proxyHost",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proxyPort",
+            "columnName": "proxyPort",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "obfsLink",
+            "columnName": "obfsLink",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingCredentialRequirements",
+            "columnName": "pendingCredentialRequirements",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "restoreAutoConnect",
+            "columnName": "restoreAutoConnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverIconUrl",
+            "columnName": "serverIconUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "network_identity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `caseMapping` TEXT, `chanTypes` TEXT, `selfNick` TEXT, PRIMARY KEY(`networkId`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "caseMapping",
+            "columnName": "caseMapping",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chanTypes",
+            "columnName": "chanTypes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selfNick",
+            "columnName": "selfNick",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "network_ignores",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `pattern` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_network_ignores_networkId_pattern",
+            "unique": true,
+            "columnNames": [
+              "networkId",
+              "pattern"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_network_ignores_networkId_pattern` ON `${TABLE_NAME}` (`networkId`, `pattern`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "chat_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `displayName` TEXT NOT NULL, `normalizedName` TEXT NOT NULL, `iconKind` TEXT NOT NULL, `iconKey` TEXT NOT NULL, `ordering` INTEGER NOT NULL, `expanded` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalizedName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKind",
+            "columnName": "iconKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "iconKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_folders_normalizedName",
+            "unique": true,
+            "columnNames": [
+              "normalizedName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chat_folders_normalizedName` ON `${TABLE_NAME}` (`normalizedName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ignored_auto_group_patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `normalizedPrefix` TEXT NOT NULL, PRIMARY KEY(`networkId`, `normalizedPrefix`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedPrefix",
+            "columnName": "normalizedPrefix",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId",
+            "normalizedPrefix"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_folder_assignments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `chatType` TEXT NOT NULL, `identityKind` TEXT NOT NULL, `identityValue` TEXT NOT NULL, `folderId` INTEGER NOT NULL, PRIMARY KEY(`networkId`, `chatType`, `identityKind`, `identityValue`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`folderId`) REFERENCES `chat_folders`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatType",
+            "columnName": "chatType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKind",
+            "columnName": "identityKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityValue",
+            "columnName": "identityValue",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId",
+            "chatType",
+            "identityKind",
+            "identityValue"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_folder_assignments_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_folder_assignments_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chat_folders",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "folderId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "buffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `type` TEXT NOT NULL, `topic` TEXT, `topicSetBy` TEXT, `joined` INTEGER NOT NULL, `membershipCycle` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `muted` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `ordering` INTEGER NOT NULL, `readMarkerTime` INTEGER, `localReadAnchorTime` INTEGER, `localReadAnchorEventId` INTEGER, `localUnreadFloorTime` INTEGER, `oldestFetchedTime` INTEGER, `historyComplete` INTEGER NOT NULL, `dismissed` INTEGER NOT NULL, `historyDiscardedThroughMsgid` TEXT, `historyDiscardedThroughTime` INTEGER, `pendingCloseAt` INTEGER, `redirectToRoomId` INTEGER, `layoutDensityOverride` TEXT, `presenceModeOverride` TEXT, `avatarOverrideModel` TEXT, `folderId` INTEGER, `monitorActivityTime` INTEGER, `advertisedLatestTime` INTEGER, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`folderId`) REFERENCES `chat_folders`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "topicSetBy",
+            "columnName": "topicSetBy",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "joined",
+            "columnName": "joined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "membershipCycle",
+            "columnName": "membershipCycle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readMarkerTime",
+            "columnName": "readMarkerTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localReadAnchorTime",
+            "columnName": "localReadAnchorTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localReadAnchorEventId",
+            "columnName": "localReadAnchorEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localUnreadFloorTime",
+            "columnName": "localUnreadFloorTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oldestFetchedTime",
+            "columnName": "oldestFetchedTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "historyComplete",
+            "columnName": "historyComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dismissed",
+            "columnName": "dismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "historyDiscardedThroughMsgid",
+            "columnName": "historyDiscardedThroughMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "historyDiscardedThroughTime",
+            "columnName": "historyDiscardedThroughTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingCloseAt",
+            "columnName": "pendingCloseAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "redirectToRoomId",
+            "columnName": "redirectToRoomId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "layoutDensityOverride",
+            "columnName": "layoutDensityOverride",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "presenceModeOverride",
+            "columnName": "presenceModeOverride",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarOverrideModel",
+            "columnName": "avatarOverrideModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monitorActivityTime",
+            "columnName": "monitorActivityTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "advertisedLatestTime",
+            "columnName": "advertisedLatestTime",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_buffers_networkId_name",
+            "unique": true,
+            "columnNames": [
+              "networkId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_buffers_networkId_name` ON `${TABLE_NAME}` (`networkId`, `name`)"
+          },
+          {
+            "name": "index_buffers_redirectToRoomId",
+            "unique": false,
+            "columnNames": [
+              "redirectToRoomId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_buffers_redirectToRoomId` ON `${TABLE_NAME}` (`redirectToRoomId`)"
+          },
+          {
+            "name": "index_buffers_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_buffers_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chat_folders",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "folderId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discarded_message_ids",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`roomId` INTEGER NOT NULL, `msgid` TEXT NOT NULL, PRIMARY KEY(`roomId`, `msgid`), FOREIGN KEY(`roomId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "msgid",
+            "columnName": "msgid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "roomId",
+            "msgid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "roomId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "room_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `namespace` TEXT NOT NULL, `value` TEXT NOT NULL, `roomId` INTEGER NOT NULL, `verified` INTEGER NOT NULL, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`roomId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "namespace",
+            "columnName": "namespace",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "verified",
+            "columnName": "verified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_room_aliases_networkId_namespace_value",
+            "unique": true,
+            "columnNames": [
+              "networkId",
+              "namespace",
+              "value"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_room_aliases_networkId_namespace_value` ON `${TABLE_NAME}` (`networkId`, `namespace`, `value`)"
+          },
+          {
+            "name": "index_room_aliases_roomId",
+            "unique": false,
+            "columnNames": [
+              "roomId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_room_aliases_roomId` ON `${TABLE_NAME}` (`roomId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "roomId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bufferId` INTEGER NOT NULL, `msgid` TEXT, `serverTime` INTEGER NOT NULL, `sender` TEXT NOT NULL, `normalizedActor` TEXT NOT NULL, `senderAccount` TEXT, `kind` TEXT NOT NULL, `text` TEXT NOT NULL, `ircFormattedText` TEXT, `isSelf` INTEGER NOT NULL, `isBot` INTEGER NOT NULL DEFAULT 0, `hasMention` INTEGER NOT NULL, `replyToMsgid` TEXT, `replyToEventId` INTEGER, `channelContext` TEXT, `pendingLabel` TEXT, `failed` INTEGER NOT NULL, `dedupKey` TEXT NOT NULL, `eventKey` TEXT, `eventPayload` TEXT, `inviteState` TEXT, `serverTimeAuthoritative` INTEGER NOT NULL, `timelineOrder` INTEGER NOT NULL, `timelineOrderConfirmed` INTEGER NOT NULL, `timeProvenance` TEXT NOT NULL, `notificationWatched` INTEGER NOT NULL DEFAULT 0, `notificationHandled` INTEGER NOT NULL, `notificationClaimed` INTEGER NOT NULL, `notificationClaimOwner` TEXT, `soundHandled` INTEGER NOT NULL, FOREIGN KEY(`bufferId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bufferId",
+            "columnName": "bufferId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "msgid",
+            "columnName": "msgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverTime",
+            "columnName": "serverTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedActor",
+            "columnName": "normalizedActor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderAccount",
+            "columnName": "senderAccount",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ircFormattedText",
+            "columnName": "ircFormattedText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isSelf",
+            "columnName": "isSelf",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasMention",
+            "columnName": "hasMention",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyToMsgid",
+            "columnName": "replyToMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyToEventId",
+            "columnName": "replyToEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelContext",
+            "columnName": "channelContext",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingLabel",
+            "columnName": "pendingLabel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failed",
+            "columnName": "failed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dedupKey",
+            "columnName": "dedupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventKey",
+            "columnName": "eventKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inviteState",
+            "columnName": "inviteState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverTimeAuthoritative",
+            "columnName": "serverTimeAuthoritative",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineOrder",
+            "columnName": "timelineOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineOrderConfirmed",
+            "columnName": "timelineOrderConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeProvenance",
+            "columnName": "timeProvenance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationWatched",
+            "columnName": "notificationWatched",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "notificationHandled",
+            "columnName": "notificationHandled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationClaimed",
+            "columnName": "notificationClaimed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationClaimOwner",
+            "columnName": "notificationClaimOwner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundHandled",
+            "columnName": "soundHandled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_bufferId_serverTime_id",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "serverTime",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_serverTime_id` ON `${TABLE_NAME}` (`bufferId`, `serverTime`, `id`)"
+          },
+          {
+            "name": "index_messages_bufferId_serverTime_timelineOrder",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "serverTime",
+              "timelineOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_serverTime_timelineOrder` ON `${TABLE_NAME}` (`bufferId`, `serverTime`, `timelineOrder`)"
+          },
+          {
+            "name": "index_messages_bufferId_hasMention_isSelf_kind_serverTime_timelineOrder_id",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "hasMention",
+              "isSelf",
+              "kind",
+              "serverTime",
+              "timelineOrder",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_hasMention_isSelf_kind_serverTime_timelineOrder_id` ON `${TABLE_NAME}` (`bufferId`, `hasMention`, `isSelf`, `kind`, `serverTime`, `timelineOrder`, `id`)"
+          },
+          {
+            "name": "index_messages_replyToEventId",
+            "unique": false,
+            "columnNames": [
+              "replyToEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_replyToEventId` ON `${TABLE_NAME}` (`replyToEventId`)"
+          },
+          {
+            "name": "index_messages_bufferId_msgid",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "msgid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_msgid` ON `${TABLE_NAME}` (`bufferId`, `msgid`)"
+          },
+          {
+            "name": "index_messages_bufferId_replyToMsgid_replyToEventId",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "replyToMsgid",
+              "replyToEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_replyToMsgid_replyToEventId` ON `${TABLE_NAME}` (`bufferId`, `replyToMsgid`, `replyToEventId`)"
+          },
+          {
+            "name": "index_messages_bufferId_pendingLabel",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "pendingLabel"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_pendingLabel` ON `${TABLE_NAME}` (`bufferId`, `pendingLabel`)"
+          },
+          {
+            "name": "index_messages_bufferId_normalizedActor_serverTime",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "normalizedActor",
+              "serverTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_bufferId_normalizedActor_serverTime` ON `${TABLE_NAME}` (`bufferId`, `normalizedActor`, `serverTime`)"
+          },
+          {
+            "name": "index_messages_serverTime_id",
+            "unique": false,
+            "columnNames": [
+              "serverTime",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_serverTime_id` ON `${TABLE_NAME}` (`serverTime`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bufferId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`text` TEXT NOT NULL, `sender` TEXT NOT NULL, content=`messages`)",
+        "fields": [
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "messages",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_messages_fts_BEFORE_UPDATE BEFORE UPDATE ON `messages` BEGIN DELETE FROM `messages_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_messages_fts_BEFORE_DELETE BEFORE DELETE ON `messages` BEGIN DELETE FROM `messages_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_messages_fts_AFTER_UPDATE AFTER UPDATE ON `messages` BEGIN INSERT INTO `messages_fts`(`docid`, `text`, `sender`) VALUES (NEW.`rowid`, NEW.`text`, NEW.`sender`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_messages_fts_AFTER_INSERT AFTER INSERT ON `messages` BEGIN INSERT INTO `messages_fts`(`docid`, `text`, `sender`) VALUES (NEW.`rowid`, NEW.`text`, NEW.`sender`); END"
+        ]
+      },
+      {
+        "tableName": "composer_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`roomId` INTEGER NOT NULL, `text` TEXT NOT NULL, `replyToEventId` INTEGER, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`roomId`), FOREIGN KEY(`roomId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyToEventId",
+            "columnName": "replyToEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "roomId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "roomId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `namespace` TEXT NOT NULL, `value` BLOB NOT NULL, `timelineEventId` INTEGER NOT NULL, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`timelineEventId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "namespace",
+            "columnName": "namespace",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineEventId",
+            "columnName": "timelineEventId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_aliases_networkId_namespace_value",
+            "unique": true,
+            "columnNames": [
+              "networkId",
+              "namespace",
+              "value"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_event_aliases_networkId_namespace_value` ON `${TABLE_NAME}` (`networkId`, `namespace`, `value`)"
+          },
+          {
+            "name": "index_event_aliases_timelineEventId",
+            "unique": false,
+            "columnNames": [
+              "timelineEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_aliases_timelineEventId` ON `${TABLE_NAME}` (`timelineEventId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineEventId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_redirects",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`losingEventId` INTEGER NOT NULL, `canonicalEventId` INTEGER NOT NULL, PRIMARY KEY(`losingEventId`), FOREIGN KEY(`canonicalEventId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "losingEventId",
+            "columnName": "losingEventId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalEventId",
+            "columnName": "canonicalEventId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "losingEventId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_redirects_canonicalEventId",
+            "unique": false,
+            "columnNames": [
+              "canonicalEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_redirects_canonicalEventId` ON `${TABLE_NAME}` (`canonicalEventId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "canonicalEventId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `timelineEventId` INTEGER NOT NULL, `origin` TEXT NOT NULL, `connectionGeneration` INTEGER, `receiveOrder` INTEGER NOT NULL, `batchId` TEXT, `timeProvenance` TEXT NOT NULL, `semanticFingerprint` BLOB NOT NULL, `batchExactOrdinal` INTEGER, `observedAt` INTEGER NOT NULL, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`timelineEventId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineEventId",
+            "columnName": "timelineEventId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectionGeneration",
+            "columnName": "connectionGeneration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "receiveOrder",
+            "columnName": "receiveOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchId",
+            "columnName": "batchId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timeProvenance",
+            "columnName": "timeProvenance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "semanticFingerprint",
+            "columnName": "semanticFingerprint",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchExactOrdinal",
+            "columnName": "batchExactOrdinal",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_observations_timelineEventId",
+            "unique": false,
+            "columnNames": [
+              "timelineEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_observations_timelineEventId` ON `${TABLE_NAME}` (`timelineEventId`)"
+          },
+          {
+            "name": "index_event_observations_networkId_receiveOrder",
+            "unique": false,
+            "columnNames": [
+              "networkId",
+              "receiveOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_observations_networkId_receiveOrder` ON `${TABLE_NAME}` (`networkId`, `receiveOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineEventId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "history_cursors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`roomId` INTEGER NOT NULL, `newestMsgid` TEXT, `newestServerTime` INTEGER, `oldestMsgid` TEXT, `oldestServerTime` INTEGER, `historyComplete` INTEGER NOT NULL, PRIMARY KEY(`roomId`), FOREIGN KEY(`roomId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newestMsgid",
+            "columnName": "newestMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "newestServerTime",
+            "columnName": "newestServerTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oldestMsgid",
+            "columnName": "oldestMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "oldestServerTime",
+            "columnName": "oldestServerTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "historyComplete",
+            "columnName": "historyComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "roomId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "roomId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "history_gaps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `roomId` INTEGER NOT NULL, `olderMsgid` TEXT, `olderServerTime` INTEGER NOT NULL, `newerMsgid` TEXT, `newerServerTime` INTEGER NOT NULL, `recoverable` INTEGER NOT NULL DEFAULT 1, `olderEventId` INTEGER, `olderTimelineOrder` INTEGER, `newerEventId` INTEGER, `newerTimelineOrder` INTEGER, FOREIGN KEY(`roomId`) REFERENCES `buffers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roomId",
+            "columnName": "roomId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "olderMsgid",
+            "columnName": "olderMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "olderServerTime",
+            "columnName": "olderServerTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newerMsgid",
+            "columnName": "newerMsgid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "newerServerTime",
+            "columnName": "newerServerTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recoverable",
+            "columnName": "recoverable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "olderEventId",
+            "columnName": "olderEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "olderTimelineOrder",
+            "columnName": "olderTimelineOrder",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "newerEventId",
+            "columnName": "newerEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "newerTimelineOrder",
+            "columnName": "newerTimelineOrder",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_history_gaps_roomId_olderServerTime",
+            "unique": false,
+            "columnNames": [
+              "roomId",
+              "olderServerTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_gaps_roomId_olderServerTime` ON `${TABLE_NAME}` (`roomId`, `olderServerTime`)"
+          },
+          {
+            "name": "index_history_gaps_roomId_newerServerTime",
+            "unique": false,
+            "columnNames": [
+              "roomId",
+              "newerServerTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_gaps_roomId_newerServerTime` ON `${TABLE_NAME}` (`roomId`, `newerServerTime`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "buffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "roomId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "network_history_cursors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `lastSuccessfulSync` INTEGER NOT NULL, `serverDerived` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`networkId`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSuccessfulSync",
+            "columnName": "lastSuccessfulSync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverDerived",
+            "columnName": "serverDerived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "history_backfill_cursors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `upperBound` INTEGER NOT NULL, `complete` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`networkId`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upperBound",
+            "columnName": "upperBound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "connection_generations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `generation` INTEGER NOT NULL, PRIMARY KEY(`networkId`), FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "app_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bufferId` INTEGER NOT NULL, `targetMsgid` TEXT NOT NULL, `actorKey` TEXT NOT NULL, `sender` TEXT NOT NULL, `emoji` TEXT NOT NULL, `serverTime` INTEGER NOT NULL, `targetEventId` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bufferId",
+            "columnName": "bufferId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetMsgid",
+            "columnName": "targetMsgid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorKey",
+            "columnName": "actorKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverTime",
+            "columnName": "serverTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetEventId",
+            "columnName": "targetEventId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reactions_bufferId_targetMsgid_actorKey_emoji",
+            "unique": true,
+            "columnNames": [
+              "bufferId",
+              "targetMsgid",
+              "actorKey",
+              "emoji"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reactions_bufferId_targetMsgid_actorKey_emoji` ON `${TABLE_NAME}` (`bufferId`, `targetMsgid`, `actorKey`, `emoji`)"
+          },
+          {
+            "name": "index_reactions_bufferId_targetMsgid_targetEventId",
+            "unique": false,
+            "columnNames": [
+              "bufferId",
+              "targetMsgid",
+              "targetEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_bufferId_targetMsgid_targetEventId` ON `${TABLE_NAME}` (`bufferId`, `targetMsgid`, `targetEventId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkId` INTEGER NOT NULL, `nick` TEXT NOT NULL, `username` TEXT, `account` TEXT, `away` INTEGER NOT NULL, `hostmask` TEXT, `realname` TEXT, `isBot` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`networkId`, `nick`))",
+        "fields": [
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nick",
+            "columnName": "nick",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "account",
+            "columnName": "account",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "away",
+            "columnName": "away",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hostmask",
+            "columnName": "hostmask",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "realname",
+            "columnName": "realname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "networkId",
+            "nick"
+          ]
+        }
+      },
+      {
+        "tableName": "members",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bufferId` INTEGER NOT NULL, `nick` TEXT NOT NULL, `prefixes` TEXT NOT NULL, `isBot` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`bufferId`, `nick`))",
+        "fields": [
+          {
+            "fieldPath": "bufferId",
+            "columnName": "bufferId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nick",
+            "columnName": "nick",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prefixes",
+            "columnName": "prefixes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bufferId",
+            "nick"
+          ]
+        }
+      },
+      {
+        "tableName": "dcc_transfers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `networkId` INTEGER NOT NULL, `timelineEventId` INTEGER, `offerKey` TEXT NOT NULL, `direction` TEXT NOT NULL, `protocol` TEXT NOT NULL, `peerNick` TEXT NOT NULL, `normalizedPeer` TEXT NOT NULL, `filename` TEXT NOT NULL, `displayFilename` TEXT NOT NULL, `address` TEXT NOT NULL, `addressKind` TEXT NOT NULL, `port` INTEGER NOT NULL, `sizeBytes` INTEGER, `token` TEXT, `state` TEXT NOT NULL, `bytesTransferred` INTEGER NOT NULL, `destinationUri` TEXT, `partialUri` TEXT, `error` TEXT, `createdAt` INTEGER NOT NULL, `expiresAt` INTEGER, `acceptedAt` INTEGER, `completedAt` INTEGER, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`networkId`) REFERENCES `networks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`timelineEventId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "networkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineEventId",
+            "columnName": "timelineEventId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offerKey",
+            "columnName": "offerKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerNick",
+            "columnName": "peerNick",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedPeer",
+            "columnName": "normalizedPeer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayFilename",
+            "columnName": "displayFilename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressKind",
+            "columnName": "addressKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesTransferred",
+            "columnName": "bytesTransferred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationUri",
+            "columnName": "destinationUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partialUri",
+            "columnName": "partialUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "acceptedAt",
+            "columnName": "acceptedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dcc_transfers_networkId_offerKey",
+            "unique": true,
+            "columnNames": [
+              "networkId",
+              "offerKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_dcc_transfers_networkId_offerKey` ON `${TABLE_NAME}` (`networkId`, `offerKey`)"
+          },
+          {
+            "name": "index_dcc_transfers_networkId_peerNick",
+            "unique": false,
+            "columnNames": [
+              "networkId",
+              "peerNick"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dcc_transfers_networkId_peerNick` ON `${TABLE_NAME}` (`networkId`, `peerNick`)"
+          },
+          {
+            "name": "index_dcc_transfers_timelineEventId",
+            "unique": false,
+            "columnNames": [
+              "timelineEventId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dcc_transfers_timelineEventId` ON `${TABLE_NAME}` (`timelineEventId`)"
+          },
+          {
+            "name": "index_dcc_transfers_state_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dcc_transfers_state_updatedAt` ON `${TABLE_NAME}` (`state`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "networks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "networkId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "messages",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineEventId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '46d56ef824f2ea62549d1429794c1621')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
@@ -1237,7 +1237,8 @@ interface MessageDao {
                   ))
               )
              AND kind IN ('PRIVMSG', 'NOTICE', 'ACTION')
-             AND (:queryRoom = 1 OR hasMention = 1)
+             AND (:queryRoom = 1 OR hasMention = 1
+                  OR (notificationWatched = 1 AND kind IN ('PRIVMSG', 'ACTION')))
            ORDER BY serverTime DESC, timelineOrder DESC, id DESC
            LIMIT :limit""",
     )
@@ -2468,7 +2469,9 @@ interface CanonicalTimelineDao {
              )
              AND (
                  (m.kind IN ('PRIVMSG', 'NOTICE', 'ACTION')
-                    AND b.type != 'SERVER' AND (b.type = 'QUERY' OR m.hasMention = 1))
+                    AND b.type != 'SERVER'
+                    AND (b.type = 'QUERY' OR m.hasMention = 1
+                         OR (m.notificationWatched = 1 AND m.kind IN ('PRIVMSG', 'ACTION'))))
                  OR (m.kind = 'INVITE' AND m.inviteState IN ('PENDING', 'FAILED'))
                  OR (m.kind = 'DCC_TRANSFER' AND m.eventPayload IS NOT NULL)
              )

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/db/Entities.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/db/Entities.kt
@@ -468,6 +468,8 @@ data class TimelineEventEntity(
         } else {
             TimeProvenance.LOCAL_CLOCK
         },
+    /** Qualified under a watch at ingestion; recovery must not consult the current watch. */
+    @ColumnInfo(defaultValue = "0") val notificationWatched: Boolean = false,
     val notificationHandled: Boolean = false,
     /** Durable two-phase notification claim; reset on startup before database-backed recovery. */
     val notificationClaimed: Boolean = false,

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/db/MotdDatabase.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/db/MotdDatabase.kt
@@ -37,7 +37,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MemberEntity::class,
         DccTransferEntity::class,
     ],
-    version = 38,
+    version = 39,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -1021,6 +1021,14 @@ val MIGRATION_37_38 =
         }
     }
 
+/** v38 -> v39 retains original watch eligibility for interrupted notification recovery. */
+val MIGRATION_38_39 =
+    object : Migration(38, 39) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE messages ADD COLUMN notificationWatched INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
 /**
  * The complete registered upgrade path, single-sourced so the runtime builder (DbModule) and the
  * migration tests cannot drift apart.
@@ -1071,6 +1079,7 @@ val ALL_MIGRATIONS: Array<Migration> =
         MIGRATION_35_36,
         MIGRATION_36_37,
         MIGRATION_37_38,
+        MIGRATION_38_39,
     )
 
 private fun legacyReactionNormalizedSender(column: String): String = "replace(replace(replace(replace(lower($column), '[', '{'), ']', '}'), '\\', '|'), '~', '^')"

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/sync/CanonicalTimelineStore.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/sync/CanonicalTimelineStore.kt
@@ -286,6 +286,7 @@ class CanonicalTimelineStore
                                 ircFormattedText = plan.ircFormattedText,
                                 pendingLabel = plan.label,
                                 dedupKey = SemanticIdentity.pendingKey(plan.label),
+                                notificationWatched = false,
                                 notificationHandled = false,
                                 notificationClaimed = false,
                                 notificationClaimOwner = null,
@@ -821,6 +822,7 @@ class CanonicalTimelineStore
                     } else {
                         existing.timeProvenance
                     },
+                notificationWatched = existing.notificationWatched || incoming.notificationWatched,
                 notificationHandled = existing.notificationHandled || incoming.notificationHandled,
                 notificationClaimed = existing.notificationClaimed || incoming.notificationClaimed,
                 notificationClaimOwner = existing.notificationClaimOwner ?: incoming.notificationClaimOwner,

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
@@ -700,6 +700,11 @@ class EventProcessor
             val hasMention =
                 !sourceIsSelf && type != BufferType.SERVER &&
                     (replyMentionsSelf || st.containsSelfMention(storedText))
+            val watchedChat =
+                !sourceIsSelf && type == BufferType.CHANNEL &&
+                    (e.kind == IrcEvent.ChatKind.PRIVMSG || e.kind == IrcEvent.ChatKind.ACTION) &&
+                    (origin == EventOrigin.LIVE || (origin == EventOrigin.PUSH && hasMention)) &&
+                    channelWatch.isActive(bufferId)
             val identitySender = st.normalize(e.source.nick)
 
             traceMessageDecision("message_classified", networkId, bufferId, e, origin) {
@@ -723,6 +728,7 @@ class EventProcessor
                     isSelf = sourceIsSelf,
                     isBot = e.isBot,
                     hasMention = hasMention,
+                    notificationWatched = watchedChat,
                     replyToMsgid = e.replyToMsgid,
                     dedupKey = SemanticIdentity.keyFor(e.ctx, identitySender, ircFormattedText ?: storedText),
                     serverTimeAuthoritative = e.ctx.serverTimeSource == ServerTimeSource.TAG,
@@ -813,10 +819,6 @@ class EventProcessor
                         }
                     }
                 }
-                val watchedChat =
-                    origin == EventOrigin.LIVE &&
-                        channelWatch.isActive(canonical.bufferId) &&
-                        (e.kind == IrcEvent.ChatKind.PRIVMSG || e.kind == IrcEvent.ChatKind.ACTION)
                 if (origin.notifies &&
                     !sourceIsSelf &&
                     shouldNotifyIncoming(type, hasMention, consoleNotice, watchedChat)
@@ -840,7 +842,7 @@ class EventProcessor
                                 replyToMsgid = canonical.replyToMsgid,
                             ),
                             consoleNotice = consoleNotice,
-                            watchedChat = watchedChat,
+                            watchedChat = canonical.notificationWatched,
                         )
                     }
                 }
@@ -4554,8 +4556,8 @@ private fun newerBoundary(
 
 /**
  * Notification hook the [EventProcessor] fires for a persisted incoming ChatMessage that already
- * passed the (DM || hasMention) filter. The concrete impl (MotdNotifications, WP5) applies the
- * remaining suppression rules (muted buffer, foregrounded buffer) and posts MessagingStyle.
+ * passed the DM, mention, or watched-channel filter. The concrete impl (MotdNotifications, WP5)
+ * applies the remaining suppression rules (muted buffer, foregrounded buffer) and posts MessagingStyle.
  */
 interface MessageNotifier {
     // suspend so implementations read Room / DataStore with plain suspend calls. The events
@@ -4578,7 +4580,7 @@ interface MessageNotifier {
         hasMention: Boolean,
         eventId: TimelineEventId,
         message: IrcEvent.ChatMessage,
-        // A live channel watch; it overrides an explicit buffer mute downstream.
+        // Qualified under a channel watch; overrides an explicit buffer mute downstream.
         watched: Boolean = false,
     ) = onIncoming(networkId, bufferId, type, hasMention, message)
 

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
@@ -4424,7 +4424,7 @@ class EventProcessor
             // Never raise a notification for a SERVER buffer: a motd line containing the user's nick
             // must not fire a mention. The bouncer console's own NOTICEs are the one exemption.
             if (!shouldNotifyIncoming(type, hasMention, consoleNotice, watchedChat)) return
-            notifier.onCanonicalIncoming(networkId, bufferId, type, hasMention, eventId, e)
+            notifier.onCanonicalIncoming(networkId, bufferId, type, hasMention, eventId, e, watchedChat)
         }
 
         /**
@@ -4578,6 +4578,8 @@ interface MessageNotifier {
         hasMention: Boolean,
         eventId: TimelineEventId,
         message: IrcEvent.ChatMessage,
+        // A live channel watch; it overrides an explicit buffer mute downstream.
+        watched: Boolean = false,
     ) = onIncoming(networkId, bufferId, type, hasMention, message)
 
     /** A local or synchronized marker advanced through this exact timeline tuple. */

--- a/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/sync/EventProcessor.kt
@@ -50,6 +50,7 @@ import io.github.trevarj.motd.irc.proto.IrcCaseMapping
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
 import io.github.trevarj.motd.irc.proto.replyReference
 import io.github.trevarj.motd.irc.proto.unreactionValue
+import io.github.trevarj.motd.service.ChannelWatch
 import io.github.trevarj.motd.service.IrcEventSink
 import kotlinx.coroutines.CancellationException
 import java.util.UUID
@@ -124,6 +125,7 @@ class EventProcessor
         private val diagnostics: DiagnosticLogger = DiagnosticLogger.Noop,
         private val canonicalTimeline: CanonicalTimelineStore = CanonicalTimelineStore(db),
         private val networkIgnoreCache: NetworkIgnoreCache = NetworkIgnoreCache(db.networkIgnoreDao()),
+        private val channelWatch: ChannelWatch = ChannelWatch.Noop,
     ) : IrcEventSink {
         private val networkDao get() = db.networkDao()
         private val networkIdentityDao get() = db.networkIdentityDao()
@@ -811,9 +813,13 @@ class EventProcessor
                         }
                     }
                 }
+                val watchedChat =
+                    origin == EventOrigin.LIVE &&
+                        channelWatch.isActive(canonical.bufferId) &&
+                        (e.kind == IrcEvent.ChatKind.PRIVMSG || e.kind == IrcEvent.ChatKind.ACTION)
                 if (origin.notifies &&
                     !sourceIsSelf &&
-                    (consoleNotice || (type != BufferType.SERVER && (type == BufferType.QUERY || hasMention)))
+                    shouldNotifyIncoming(type, hasMention, consoleNotice, watchedChat)
                 ) {
                     presentNotification(canonical.id) {
                         maybeNotify(
@@ -834,6 +840,7 @@ class EventProcessor
                                 replyToMsgid = canonical.replyToMsgid,
                             ),
                             consoleNotice = consoleNotice,
+                            watchedChat = watchedChat,
                         )
                     }
                 }
@@ -4411,12 +4418,12 @@ class EventProcessor
             eventId: TimelineEventId,
             e: IrcEvent.ChatMessage,
             consoleNotice: Boolean = false,
+            watchedChat: Boolean = false,
         ) {
             if (e.isSelf) return
             // Never raise a notification for a SERVER buffer: a motd line containing the user's nick
             // must not fire a mention. The bouncer console's own NOTICEs are the one exemption.
-            if (type == BufferType.SERVER && !consoleNotice) return
-            if (type != BufferType.QUERY && !hasMention && !consoleNotice) return
+            if (!shouldNotifyIncoming(type, hasMention, consoleNotice, watchedChat)) return
             notifier.onCanonicalIncoming(networkId, bufferId, type, hasMention, eventId, e)
         }
 
@@ -4612,4 +4619,15 @@ interface MessageNotifier {
             message: IrcEvent.ChatMessage,
         ) = Unit
     }
+}
+
+internal fun shouldNotifyIncoming(
+    type: BufferType,
+    hasMention: Boolean,
+    consoleNotice: Boolean,
+    watchedChat: Boolean,
+): Boolean {
+    if (consoleNotice) return true
+    if (type == BufferType.SERVER) return false
+    return type == BufferType.QUERY || hasMention || watchedChat
 }

--- a/app/src/main/kotlin/io/github/trevarj/motd/di/AppModule.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/di/AppModule.kt
@@ -96,6 +96,8 @@ import io.github.trevarj.motd.push.WebPushCryptoFacade
 import io.github.trevarj.motd.service.AndroidChatSoundPlayer
 import io.github.trevarj.motd.service.AppVisibility
 import io.github.trevarj.motd.service.ChannelCloseCoordinator
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchImpl
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.ForegroundBufferTracker
 import io.github.trevarj.motd.service.HistoryResyncController
@@ -262,6 +264,9 @@ internal abstract class AppModule {
 
     @Binds @Singleton
     abstract fun chatSoundPlayer(impl: AndroidChatSoundPlayer): ChatSoundPlayer
+
+    @Binds @Singleton
+    abstract fun channelWatch(impl: ChannelWatchImpl): ChannelWatch
 
     @Binds @Singleton
     abstract fun diagnosticLogger(impl: FileDiagnosticLogger): DiagnosticLogger

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
@@ -5,16 +5,23 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.trevarj.motd.data.db.BufferDao
 import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.di.ApplicationScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -44,7 +51,7 @@ val ChannelWatchState.isForever: Boolean get() = expiresAt == Long.MAX_VALUE
 interface ChannelWatch {
     val state: StateFlow<ChannelWatchState?>
 
-    fun isActive(bufferId: Long): Boolean
+    suspend fun isActive(bufferId: Long): Boolean
 
     /** [durationMs] null watches forever. */
     suspend fun start(
@@ -57,7 +64,7 @@ interface ChannelWatch {
     object Noop : ChannelWatch {
         override val state: StateFlow<ChannelWatchState?> = MutableStateFlow(null)
 
-        override fun isActive(bufferId: Long): Boolean = false
+        override suspend fun isActive(bufferId: Long): Boolean = false
 
         override suspend fun start(
             bufferId: Long,
@@ -79,6 +86,8 @@ class ChannelWatchImpl internal constructor(
     private val onExpired: suspend (Long) -> Unit,
     private val load: suspend () -> ChannelWatchState? = { null },
     private val save: suspend (ChannelWatchState?) -> Unit = {},
+    private val resolveBufferId: suspend (Long) -> Long? = { it },
+    private val observeBufferId: (Long) -> Flow<Long?> = { flowOf(it) },
 ) : ChannelWatch {
     @Inject
     constructor(
@@ -86,6 +95,7 @@ class ChannelWatchImpl internal constructor(
         @ApplicationContext context: Context,
         clock: AppClock,
         notifications: MotdNotifications,
+        bufferDao: BufferDao,
     ) : this(
         scope = scope,
         clock = clock,
@@ -111,6 +121,8 @@ class ChannelWatchImpl internal constructor(
                 }
             }
         },
+        resolveBufferId = bufferDao::canonicalId,
+        observeBufferId = { id -> bufferDao.observe(id).map { it?.id } },
     )
 
     private val _state = MutableStateFlow<ChannelWatchState?>(null)
@@ -124,22 +136,44 @@ class ChannelWatchImpl internal constructor(
             try {
                 lock.withLock {
                     val saved = load() ?: return@withLock
-                    if (clock.nowMillis() >= saved.expiresAt) {
+                    val bufferId = resolveBufferId(saved.bufferId)
+                    if (bufferId == null || clock.nowMillis() >= saved.expiresAt) {
                         save(null)
-                        onExpired(saved.bufferId)
+                        if (bufferId != null) onExpired(bufferId)
                     } else {
-                        armLocked(saved)
+                        val next = if (bufferId == saved.bufferId) saved else saved.copy(bufferId = bufferId)
+                        if (next != saved) save(next)
+                        armLocked(next)
                     }
                 }
             } finally {
                 restored.complete(Unit)
             }
+            _state.collectLatest { current ->
+                if (current == null) return@collectLatest
+                observeBufferId(current.bufferId).distinctUntilChanged().collect { bufferId ->
+                    lock.withLock {
+                        if (_state.value != current || bufferId == current.bufferId) return@withLock
+                        val next = bufferId?.let { current.copy(bufferId = it) }
+                        save(next)
+                        armLocked(next)
+                    }
+                }
+            }
         }
     }
 
-    override fun isActive(bufferId: Long): Boolean {
+    override suspend fun isActive(bufferId: Long): Boolean {
+        restored.await()
         val current = _state.value ?: return false
-        return current.bufferId == bufferId && clock.nowMillis() < current.expiresAt
+        if (current.bufferId == bufferId) return clock.nowMillis() < current.expiresAt
+        // A live event can arrive before Room publishes the redirect to the state observer.
+        return lock.withLock {
+            val latest = _state.value ?: return@withLock false
+            clock.nowMillis() < latest.expiresAt &&
+                (latest.bufferId == bufferId || resolveBufferId(latest.bufferId) == bufferId) &&
+                clock.nowMillis() < latest.expiresAt
+        }
     }
 
     override suspend fun start(
@@ -148,8 +182,9 @@ class ChannelWatchImpl internal constructor(
     ) {
         restored.await()
         lock.withLock {
+            val canonicalId = resolveBufferId(bufferId) ?: return@withLock
             val expiresAt = if (durationMs == null) Long.MAX_VALUE else clock.nowMillis() + durationMs
-            val next = ChannelWatchState(bufferId, expiresAt)
+            val next = ChannelWatchState(canonicalId, expiresAt)
             save(next)
             armLocked(next)
         }
@@ -158,18 +193,16 @@ class ChannelWatchImpl internal constructor(
     override suspend fun stop() {
         restored.await()
         lock.withLock {
-            timer?.cancel()
-            timer = null
-            _state.value = null
+            armLocked(null)
             save(null)
         }
     }
 
-    private fun armLocked(next: ChannelWatchState) {
+    private fun armLocked(next: ChannelWatchState?) {
         timer?.cancel()
         timer = null
         _state.value = next
-        if (next.isForever) return
+        if (next == null || next.isForever) return
         val wait = (next.expiresAt - clock.nowMillis()).coerceAtLeast(0L)
         timer =
             scope.launch {
@@ -179,7 +212,7 @@ class ChannelWatchImpl internal constructor(
                     timer = null
                     _state.value = null
                     save(null)
-                    onExpired(next.bufferId)
+                    resolveBufferId(next.bufferId)?.let { onExpired(it) }
                 }
             }
     }

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
@@ -1,0 +1,170 @@
+package io.github.trevarj.motd.service
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.trevarj.motd.di.ApplicationScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+const val CHANNEL_WATCH_15_MS = 15 * 60 * 1000L
+const val CHANNEL_WATCH_30_MS = 30 * 60 * 1000L
+const val CHANNEL_WATCH_60_MS = 60 * 60 * 1000L
+
+data class ChannelWatchState(
+    val bufferId: Long,
+    val expiresAt: Long,
+)
+
+/** One channel at a time: notify on every live PRIVMSG/ACTION until [expiresAt]. */
+interface ChannelWatch {
+    val state: StateFlow<ChannelWatchState?>
+
+    fun isActive(bufferId: Long): Boolean
+
+    suspend fun start(
+        bufferId: Long,
+        durationMs: Long,
+    )
+
+    suspend fun stop()
+
+    object Noop : ChannelWatch {
+        override val state: StateFlow<ChannelWatchState?> = MutableStateFlow(null)
+
+        override fun isActive(bufferId: Long): Boolean = false
+
+        override suspend fun start(
+            bufferId: Long,
+            durationMs: Long,
+        ) = Unit
+
+        override suspend fun stop() = Unit
+    }
+}
+
+private val Context.channelWatchDataStore by preferencesDataStore("channel_watch")
+private val BUFFER_ID = longPreferencesKey("buffer_id")
+private val EXPIRES_AT = longPreferencesKey("expires_at")
+
+@Singleton
+class ChannelWatchImpl(
+    private val scope: CoroutineScope,
+    private val clock: () -> Long,
+    private val onExpired: suspend (Long) -> Unit,
+    private val load: suspend () -> ChannelWatchState? = { null },
+    private val save: suspend (ChannelWatchState?) -> Unit = {},
+) : ChannelWatch {
+    @Inject
+    constructor(
+        @ApplicationScope scope: CoroutineScope,
+        @ApplicationContext context: Context,
+        notifications: MotdNotifications,
+    ) : this(
+        scope = scope,
+        clock = { System.currentTimeMillis() },
+        onExpired = { notifications.watchEnded(it) },
+        load = {
+            val prefs = context.channelWatchDataStore.data.first()
+            val bufferId = prefs[BUFFER_ID]
+            val expiresAt = prefs[EXPIRES_AT]
+            if (bufferId == null || expiresAt == null) {
+                null
+            } else {
+                ChannelWatchState(bufferId, expiresAt)
+            }
+        },
+        save = { state ->
+            context.channelWatchDataStore.edit { prefs ->
+                if (state == null) {
+                    prefs.remove(BUFFER_ID)
+                    prefs.remove(EXPIRES_AT)
+                } else {
+                    prefs[BUFFER_ID] = state.bufferId
+                    prefs[EXPIRES_AT] = state.expiresAt
+                }
+            }
+        },
+    )
+
+    private val _state = MutableStateFlow<ChannelWatchState?>(null)
+    override val state: StateFlow<ChannelWatchState?> = _state.asStateFlow()
+    private val lock = Mutex()
+    private val restored = CompletableDeferred<Unit>()
+    private var timer: Job? = null
+
+    init {
+        scope.launch {
+            try {
+                lock.withLock {
+                    val saved = load() ?: return@withLock
+                    if (clock() >= saved.expiresAt) {
+                        save(null)
+                        onExpired(saved.bufferId)
+                    } else {
+                        armLocked(saved)
+                    }
+                }
+            } finally {
+                restored.complete(Unit)
+            }
+        }
+    }
+
+    override fun isActive(bufferId: Long): Boolean {
+        val current = _state.value ?: return false
+        return current.bufferId == bufferId && clock() < current.expiresAt
+    }
+
+    override suspend fun start(
+        bufferId: Long,
+        durationMs: Long,
+    ) {
+        restored.await()
+        lock.withLock {
+            val next = ChannelWatchState(bufferId, clock() + durationMs)
+            save(next)
+            armLocked(next)
+        }
+    }
+
+    override suspend fun stop() {
+        restored.await()
+        lock.withLock {
+            timer?.cancel()
+            timer = null
+            _state.value = null
+            save(null)
+        }
+    }
+
+    private fun armLocked(next: ChannelWatchState) {
+        timer?.cancel()
+        _state.value = next
+        val wait = (next.expiresAt - clock()).coerceAtLeast(0L)
+        timer =
+            scope.launch {
+                delay(wait)
+                lock.withLock {
+                    if (_state.value != next) return@withLock
+                    timer = null
+                    _state.value = null
+                    save(null)
+                    onExpired(next.bufferId)
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.di.ApplicationScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -20,9 +21,17 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val CHANNEL_WATCH_15_MS = 15 * 60 * 1000L
-const val CHANNEL_WATCH_30_MS = 30 * 60 * 1000L
-const val CHANNEL_WATCH_60_MS = 60 * 60 * 1000L
+/** Offered watch durations. Shared by the chat overflow and the channel-info notifications row. */
+enum class ChannelWatchDuration(
+    val millis: Long,
+) {
+    MIN_15(15 * 60 * 1000L),
+    MIN_30(30 * 60 * 1000L),
+    MIN_60(60 * 60 * 1000L),
+    ;
+
+    val minutes: Int get() = (millis / 60_000L).toInt()
+}
 
 data class ChannelWatchState(
     val bufferId: Long,
@@ -61,9 +70,9 @@ private val BUFFER_ID = longPreferencesKey("buffer_id")
 private val EXPIRES_AT = longPreferencesKey("expires_at")
 
 @Singleton
-class ChannelWatchImpl(
+class ChannelWatchImpl internal constructor(
     private val scope: CoroutineScope,
-    private val clock: () -> Long,
+    private val clock: AppClock,
     private val onExpired: suspend (Long) -> Unit,
     private val load: suspend () -> ChannelWatchState? = { null },
     private val save: suspend (ChannelWatchState?) -> Unit = {},
@@ -72,10 +81,11 @@ class ChannelWatchImpl(
     constructor(
         @ApplicationScope scope: CoroutineScope,
         @ApplicationContext context: Context,
+        clock: AppClock,
         notifications: MotdNotifications,
     ) : this(
         scope = scope,
-        clock = { System.currentTimeMillis() },
+        clock = clock,
         onExpired = { notifications.watchEnded(it) },
         load = {
             val prefs = context.channelWatchDataStore.data.first()
@@ -111,7 +121,7 @@ class ChannelWatchImpl(
             try {
                 lock.withLock {
                     val saved = load() ?: return@withLock
-                    if (clock() >= saved.expiresAt) {
+                    if (clock.nowMillis() >= saved.expiresAt) {
                         save(null)
                         onExpired(saved.bufferId)
                     } else {
@@ -126,7 +136,7 @@ class ChannelWatchImpl(
 
     override fun isActive(bufferId: Long): Boolean {
         val current = _state.value ?: return false
-        return current.bufferId == bufferId && clock() < current.expiresAt
+        return current.bufferId == bufferId && clock.nowMillis() < current.expiresAt
     }
 
     override suspend fun start(
@@ -135,7 +145,7 @@ class ChannelWatchImpl(
     ) {
         restored.await()
         lock.withLock {
-            val next = ChannelWatchState(bufferId, clock() + durationMs)
+            val next = ChannelWatchState(bufferId, clock.nowMillis() + durationMs)
             save(next)
             armLocked(next)
         }
@@ -154,7 +164,7 @@ class ChannelWatchImpl(
     private fun armLocked(next: ChannelWatchState) {
         timer?.cancel()
         _state.value = next
-        val wait = (next.expiresAt - clock()).coerceAtLeast(0L)
+        val wait = (next.expiresAt - clock.nowMillis()).coerceAtLeast(0L)
         timer =
             scope.launch {
                 delay(wait)

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/ChannelWatch.kt
@@ -21,16 +21,15 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/** Offered watch durations. Shared by the chat overflow and the channel-info notifications row. */
+/** Offered watch durations; [millis] null means forever. [tag] is the stable UI test-tag suffix. */
 enum class ChannelWatchDuration(
-    val millis: Long,
+    val millis: Long?,
+    val tag: String,
 ) {
-    MIN_15(15 * 60 * 1000L),
-    MIN_30(30 * 60 * 1000L),
-    MIN_60(60 * 60 * 1000L),
-    ;
-
-    val minutes: Int get() = (millis / 60_000L).toInt()
+    MIN_15(15 * 60 * 1000L, "15"),
+    MIN_30(30 * 60 * 1000L, "30"),
+    MIN_60(60 * 60 * 1000L, "60"),
+    FOREVER(null, "forever"),
 }
 
 data class ChannelWatchState(
@@ -38,15 +37,19 @@ data class ChannelWatchState(
     val expiresAt: Long,
 )
 
+/** A forever watch is stored as a sentinel expiry and never runs an expiry timer. */
+val ChannelWatchState.isForever: Boolean get() = expiresAt == Long.MAX_VALUE
+
 /** One channel at a time: notify on every live PRIVMSG/ACTION until [expiresAt]. */
 interface ChannelWatch {
     val state: StateFlow<ChannelWatchState?>
 
     fun isActive(bufferId: Long): Boolean
 
+    /** [durationMs] null watches forever. */
     suspend fun start(
         bufferId: Long,
-        durationMs: Long,
+        durationMs: Long?,
     )
 
     suspend fun stop()
@@ -58,7 +61,7 @@ interface ChannelWatch {
 
         override suspend fun start(
             bufferId: Long,
-            durationMs: Long,
+            durationMs: Long?,
         ) = Unit
 
         override suspend fun stop() = Unit
@@ -141,11 +144,12 @@ class ChannelWatchImpl internal constructor(
 
     override suspend fun start(
         bufferId: Long,
-        durationMs: Long,
+        durationMs: Long?,
     ) {
         restored.await()
         lock.withLock {
-            val next = ChannelWatchState(bufferId, clock.nowMillis() + durationMs)
+            val expiresAt = if (durationMs == null) Long.MAX_VALUE else clock.nowMillis() + durationMs
+            val next = ChannelWatchState(bufferId, expiresAt)
             save(next)
             armLocked(next)
         }
@@ -163,7 +167,9 @@ class ChannelWatchImpl internal constructor(
 
     private fun armLocked(next: ChannelWatchState) {
         timer?.cancel()
+        timer = null
         _state.value = next
+        if (next.isForever) return
         val wait = (next.expiresAt - clock.nowMillis()).coerceAtLeast(0L)
         timer =
             scope.launch {

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
@@ -119,8 +119,11 @@ class MotdNotifications
         internal fun retireLegacyMessageNotifications() {
             runCatching {
                 manager.activeNotifications
-                    .filter { it.notification.channelId in MESSAGE_CHANNELS && !isMessageNotificationId(it.id) }
-                    .forEach { legacy ->
+                    .filter {
+                        it.notification.channelId in MESSAGE_CHANNELS &&
+                            !isMessageNotificationId(it.id) &&
+                            it.id != WATCH_ENDED_ID
+                    }.forEach { legacy ->
                         manager.cancel(legacy.id)
                         diagnostics.record("notifications", "legacy_message_id_retired") {
                             mapOf("notification_id" to legacy.id, "channel" to legacy.notification.channelId)
@@ -695,6 +698,37 @@ class MotdNotifications
             if (canPost) manager.notify(invitationNotificationId(canonicalMessageId), notification)
         }
 
+        suspend fun watchEnded(bufferId: Long) {
+            val name = db.bufferDao().observeById(bufferId)?.displayName ?: return
+            val text = context.getString(io.github.trevarj.motd.R.string.notification_watch_ended, name)
+            val contentIntent =
+                PendingIntent.getActivity(
+                    context,
+                    WATCH_ENDED_ID,
+                    Intent(context, MainActivity::class.java)
+                        .setAction(ACTION_OPEN_BUFFER)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                        .putExtra(EXTRA_BUFFER_ID, bufferId),
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            val notification =
+                NotificationCompat
+                    .Builder(context, CHANNEL_MESSAGES)
+                    .setSmallIcon(io.github.trevarj.motd.R.drawable.ic_notification_motd)
+                    .setContentTitle(text)
+                    .setContentText(text)
+                    .setContentIntent(contentIntent)
+                    .setAutoCancel(true)
+                    .build()
+            val canPost =
+                android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU ||
+                    androidx.core.content.ContextCompat.checkSelfPermission(
+                        context,
+                        android.Manifest.permission.POST_NOTIFICATIONS,
+                    ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+            if (canPost) manager.notify(WATCH_ENDED_ID, notification)
+        }
+
         override suspend fun onInvitationResolved(messageId: Long) {
             val canonicalId = db.canonicalTimelineDao().canonicalEventId(messageId)
             manager.cancel(invitationNotificationId(canonicalId))
@@ -895,6 +929,7 @@ class MotdNotifications
 
             private const val MESSAGE_ID_NAMESPACE = 0x10000000
             private const val NAMESPACE_MASK = -0x10000000 // 0xf0000000
+            private const val WATCH_ENDED_ID = 0x30000001
         }
     }
 

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
@@ -53,7 +53,7 @@ import javax.inject.Singleton
  * Precedence (highest first): foreground buffer suppresses everything; an explicit buffer mute
  * always wins over friend status; a fool sender is fully silenced. The `(DM || mention)` gate lives upstream in
  * [io.github.trevarj.motd.data.sync.EventProcessor.maybeNotify], so by the time this runs the
- * message already qualifies as a DM or a mention.
+ * message already qualifies as a DM, a mention, or a watched-channel message.
  */
 fun shouldPostNotification(
     foreground: Boolean,
@@ -61,7 +61,8 @@ fun shouldPostNotification(
     senderIsFriend: Boolean,
     senderIsFool: Boolean,
     alreadyRead: Boolean = false,
-): Boolean = !alreadyRead && !foreground && !muted && !senderIsFool
+    watched: Boolean = false,
+): Boolean = !alreadyRead && !foreground && !(muted && !watched) && !senderIsFool
 
 /**
  * MessagingStyle notifications. Owns the notification channels and applies the final
@@ -301,7 +302,8 @@ class MotdNotifications
             hasMention: Boolean,
             eventId: Long,
             message: IrcEvent.ChatMessage,
-        ) = postIncoming(networkId, bufferId, type, hasMention, eventId, message, firstPresentation = true)
+            watched: Boolean,
+        ) = postIncoming(networkId, bufferId, type, hasMention, eventId, message, firstPresentation = true, watched = watched)
 
         private suspend fun postIncoming(
             networkId: Long,
@@ -311,6 +313,7 @@ class MotdNotifications
             eventId: Long?,
             message: IrcEvent.ChatMessage,
             firstPresentation: Boolean,
+            watched: Boolean = false,
         ) {
             // Plain suspend reads: Room and DataStore dispatch off the main thread on their own. The
             // events collector runs on Dispatchers.Main, so the previous runBlocking { suspend query }
@@ -351,7 +354,8 @@ class MotdNotifications
                     ?: TimelineAnchor(message.ctx.serverTime, 0L)
             val effectiveReadAnchor = buffer?.let { effectiveLocalReadAnchor(it) }
             val alreadyRead = effectiveReadAnchor?.let { incomingAnchor <= it } == true
-            val decision = shouldPostNotification(foreground, muted, senderIsFriend, senderIsFool, alreadyRead)
+            val decision =
+                shouldPostNotification(foreground, muted, senderIsFriend, senderIsFool, alreadyRead, watched = watched)
             diagnostics.record("notifications", "message_evaluated") {
                 mapOf(
                     "network_id" to networkId,
@@ -364,6 +368,7 @@ class MotdNotifications
                     "friend" to senderIsFriend,
                     "fool" to senderIsFool,
                     "already_read" to alreadyRead,
+                    "watched" to watched,
                     "post" to decision,
                     "mention" to hasMention,
                 )
@@ -715,7 +720,7 @@ class MotdNotifications
                 NotificationCompat
                     .Builder(context, CHANNEL_MESSAGES)
                     .setSmallIcon(io.github.trevarj.motd.R.drawable.ic_notification_motd)
-                    .setContentTitle(text)
+                    .setContentTitle(context.getString(io.github.trevarj.motd.R.string.notification_watch_ended_title))
                     .setContentText(text)
                     .setContentIntent(contentIntent)
                     .setAutoCancel(true)

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
@@ -50,10 +50,10 @@ import javax.inject.Singleton
 /**
  * Final notification suppression decision. Pure and unit-tested.
  *
- * Precedence (highest first): foreground buffer suppresses everything; an explicit buffer mute
- * always wins over friend status; a fool sender is fully silenced. The `(DM || mention)` gate lives upstream in
- * [io.github.trevarj.motd.data.sync.EventProcessor.maybeNotify], so by the time this runs the
- * message already qualifies as a DM, a mention, or a watched-channel message.
+ * Precedence (highest first): already-read and foreground buffers suppress everything; an explicit
+ * buffer mute wins unless the message qualified under a watch; a fool sender is fully silenced.
+ * The DM, mention, or watched-channel qualification lives upstream in
+ * [io.github.trevarj.motd.data.sync.EventProcessor.maybeNotify].
  */
 fun shouldPostNotification(
     foreground: Boolean,
@@ -170,6 +170,7 @@ class MotdNotifications
                                 // about (the claim/present/complete cycle was interrupted after an
                                 // unknown amount of presentation work); it must never re-alert.
                                 firstPresentation = false,
+                                watched = event.notificationWatched,
                                 message =
                                     IrcEvent.ChatMessage(
                                         ctx =
@@ -338,7 +339,7 @@ class MotdNotifications
                     identityRules,
                 )
 
-            // Fools and explicit buffer mute are fully silent. Foreground suppression also applies.
+            // Only a watch bypasses buffer mute; fools, read markers, and foreground still suppress.
             val foreground = foregroundBufferTracker.foregroundBufferId.value == bufferId
             val muted = buffer?.muted == true
             val senderIsFriend = identityRules.matchesConfiguredNick(message.source.nick, settings.friends)

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -52,6 +53,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
@@ -73,6 +75,7 @@ import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.JoinedChannelRow
 import io.github.trevarj.motd.data.db.MemberEntity
 import io.github.trevarj.motd.data.prefs.matchesConfiguredNick
+import io.github.trevarj.motd.service.ChannelWatchDuration
 import io.github.trevarj.motd.service.RosterLoadState
 import io.github.trevarj.motd.ui.chat.AttachmentSheets
 import io.github.trevarj.motd.ui.chat.InviteSheetTarget
@@ -85,6 +88,7 @@ import io.github.trevarj.motd.ui.components.AvatarEditorSheet
 import io.github.trevarj.motd.ui.components.MuteBacklogUndoEffect
 import io.github.trevarj.motd.ui.components.avatarsHidden
 import io.github.trevarj.motd.ui.components.botDisplayName
+import io.github.trevarj.motd.ui.components.label
 import io.github.trevarj.motd.ui.theme.MotdMotion
 import io.github.trevarj.motd.ui.theme.MotdTheme
 
@@ -105,6 +109,7 @@ fun ChannelInfoScreen(
     val leaveMutation by viewModel.leaveMutation.collectAsStateWithLifecycle()
     val inviteFeedback by viewModel.inviteFeedback.collectAsStateWithLifecycle()
     val presenceStates by viewModel.presenceStates.collectAsStateWithLifecycle()
+    val notifyLevel by viewModel.notifyLevel.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel, onBack) {
         viewModel.operationEvents.collect { event ->
@@ -236,6 +241,9 @@ fun ChannelInfoScreen(
         onQueryChange = viewModel::setQuery,
         onEditAvatar = { avatarEditorOpen = true },
         onCreateInvite = { onCreateInvite(bufferId) },
+        notifyLevel = notifyLevel,
+        onStartWatch = viewModel::startWatch,
+        onStopWatch = viewModel::stopWatch,
     )
 
     AvatarEditorSheet(
@@ -396,7 +404,11 @@ fun ChannelInfoContent(
     onQueryChange: (String) -> Unit = {},
     onEditAvatar: () -> Unit = {},
     onCreateInvite: () -> Unit = {},
+    notifyLevel: ChannelNotifyLevel = ChannelNotifyLevel.MentionsOnly,
+    onStartWatch: (ChannelWatchDuration) -> Unit = {},
+    onStopWatch: () -> Unit = {},
 ) {
+    var showNotifyPicker by remember { mutableStateOf(false) }
     var showLeaveConfirm by remember { mutableStateOf(false) }
     var showTopicEdit by remember { mutableStateOf(false) }
     // Fools section is collapsed by default; state is local to the screen.
@@ -450,6 +462,11 @@ fun ChannelInfoContent(
                     onEditAvatar = onEditAvatar,
                     onCreateInvite = onCreateInvite,
                 )
+            }
+            if (buffer?.type == BufferType.CHANNEL) {
+                item(key = "notify_level") {
+                    NotifyLevelRow(level = notifyLevel, onClick = { showNotifyPicker = true })
+                }
             }
             // Non-ops get no section at all rather than a wall of disabled controls; the gate
             // resolves after the roster loads, so it can appear a moment after the screen does.
@@ -619,6 +636,21 @@ fun ChannelInfoContent(
                 }
             }
         }
+    }
+
+    if (showNotifyPicker) {
+        NotifyLevelDialog(
+            watchActive = notifyLevel is ChannelNotifyLevel.All,
+            onDismiss = { showNotifyPicker = false },
+            onStartWatch = {
+                showNotifyPicker = false
+                onStartWatch(it)
+            },
+            onStopWatch = {
+                showNotifyPicker = false
+                onStopWatch()
+            },
+        )
     }
 
     if (showLeaveConfirm) {
@@ -878,6 +910,94 @@ private fun ChannelHeader(
             }
         }
     }
+}
+
+@Composable
+private fun NotifyLevelRow(
+    level: ChannelNotifyLevel,
+    onClick: () -> Unit,
+) {
+    val supporting =
+        when (level) {
+            ChannelNotifyLevel.MentionsOnly -> {
+                stringResource(R.string.channelinfo_notify_mentions)
+            }
+
+            ChannelNotifyLevel.Muted -> {
+                stringResource(R.string.channelinfo_notify_muted)
+            }
+
+            is ChannelNotifyLevel.All -> {
+                stringResource(
+                    if (level.overridesMute) {
+                        R.string.channelinfo_notify_overrides_mute
+                    } else {
+                        R.string.channelinfo_notify_all
+                    },
+                    level.minutesLeft,
+                )
+            }
+        }
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.channelinfo_notifications)) },
+        supportingContent = { Text(supporting) },
+        leadingContent = {
+            Icon(
+                if (level is ChannelNotifyLevel.Muted) Icons.Outlined.NotificationsOff else Icons.Outlined.Notifications,
+                contentDescription = null,
+            )
+        },
+        modifier = Modifier.testTag("channelinfo_notify_level").clickable(onClick = onClick),
+    )
+}
+
+@Composable
+private fun NotifyLevelDialog(
+    watchActive: Boolean,
+    onDismiss: () -> Unit,
+    onStartWatch: (ChannelWatchDuration) -> Unit,
+    onStopWatch: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        // Same opt-in as the leave dialog: a dialog window does not inherit the root's tag mapping.
+        modifier =
+            Modifier
+                .semantics { testTagsAsResourceId = true }
+                .testTag("channelinfo_notify_dialog"),
+        title = { Text(stringResource(R.string.channelinfo_notifications)) },
+        text = {
+            Column {
+                ChannelWatchDuration.entries.forEach { duration ->
+                    ListItem(
+                        headlineContent = { Text(duration.label()) },
+                        leadingContent = { Icon(Icons.Outlined.Notifications, contentDescription = null) },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        modifier =
+                            Modifier
+                                .testTag("channelinfo_watch_${duration.minutes}")
+                                .clickable { onStartWatch(duration) },
+                    )
+                }
+                if (watchActive) {
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.chat_watch_stop)) },
+                        leadingContent = { Icon(Icons.Outlined.NotificationsOff, contentDescription = null) },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        modifier =
+                            Modifier
+                                .testTag("channelinfo_watch_stop")
+                                .clickable { onStopWatch() },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -53,7 +52,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
@@ -85,10 +83,10 @@ import io.github.trevarj.motd.ui.chat.NickActionSheet
 import io.github.trevarj.motd.ui.chat.lagTone
 import io.github.trevarj.motd.ui.components.Avatar
 import io.github.trevarj.motd.ui.components.AvatarEditorSheet
+import io.github.trevarj.motd.ui.components.ChannelWatchDialog
 import io.github.trevarj.motd.ui.components.MuteBacklogUndoEffect
 import io.github.trevarj.motd.ui.components.avatarsHidden
 import io.github.trevarj.motd.ui.components.botDisplayName
-import io.github.trevarj.motd.ui.components.label
 import io.github.trevarj.motd.ui.theme.MotdMotion
 import io.github.trevarj.motd.ui.theme.MotdTheme
 
@@ -639,17 +637,12 @@ fun ChannelInfoContent(
     }
 
     if (showNotifyPicker) {
-        NotifyLevelDialog(
+        ChannelWatchDialog(
             watchActive = notifyLevel is ChannelNotifyLevel.All,
+            onStart = onStartWatch,
+            onStop = onStopWatch,
             onDismiss = { showNotifyPicker = false },
-            onStartWatch = {
-                showNotifyPicker = false
-                onStartWatch(it)
-            },
-            onStopWatch = {
-                showNotifyPicker = false
-                onStopWatch()
-            },
+            tagPrefix = "channelinfo",
         )
     }
 
@@ -928,14 +921,25 @@ private fun NotifyLevelRow(
             }
 
             is ChannelNotifyLevel.All -> {
-                stringResource(
-                    if (level.overridesMute) {
-                        R.string.channelinfo_notify_overrides_mute
-                    } else {
-                        R.string.channelinfo_notify_all
-                    },
-                    level.minutesLeft,
-                )
+                val minutesLeft = level.minutesLeft
+                if (minutesLeft == null) {
+                    stringResource(
+                        if (level.overridesMute) {
+                            R.string.channelinfo_notify_all_forever_overrides_mute
+                        } else {
+                            R.string.channelinfo_notify_all_forever
+                        },
+                    )
+                } else {
+                    stringResource(
+                        if (level.overridesMute) {
+                            R.string.channelinfo_notify_overrides_mute
+                        } else {
+                            R.string.channelinfo_notify_all
+                        },
+                        minutesLeft,
+                    )
+                }
             }
         }
     ListItem(
@@ -948,55 +952,6 @@ private fun NotifyLevelRow(
             )
         },
         modifier = Modifier.testTag("channelinfo_notify_level").clickable(onClick = onClick),
-    )
-}
-
-@Composable
-private fun NotifyLevelDialog(
-    watchActive: Boolean,
-    onDismiss: () -> Unit,
-    onStartWatch: (ChannelWatchDuration) -> Unit,
-    onStopWatch: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        // Same opt-in as the leave dialog: a dialog window does not inherit the root's tag mapping.
-        modifier =
-            Modifier
-                .semantics { testTagsAsResourceId = true }
-                .testTag("channelinfo_notify_dialog"),
-        title = { Text(stringResource(R.string.channelinfo_notifications)) },
-        text = {
-            Column {
-                ChannelWatchDuration.entries.forEach { duration ->
-                    ListItem(
-                        headlineContent = { Text(duration.label()) },
-                        leadingContent = { Icon(Icons.Outlined.Notifications, contentDescription = null) },
-                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        modifier =
-                            Modifier
-                                .testTag("channelinfo_watch_${duration.minutes}")
-                                .clickable { onStartWatch(duration) },
-                    )
-                }
-                if (watchActive) {
-                    ListItem(
-                        headlineContent = { Text(stringResource(R.string.chat_watch_stop)) },
-                        leadingContent = { Icon(Icons.Outlined.NotificationsOff, contentDescription = null) },
-                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        modifier =
-                            Modifier
-                                .testTag("channelinfo_watch_stop")
-                                .clickable { onStopWatch() },
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.action_cancel))
-            }
-        },
     )
 }
 

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
@@ -21,9 +21,13 @@ import io.github.trevarj.motd.data.prefs.matchesConfiguredNick
 import io.github.trevarj.motd.data.repo.BufferRepository
 import io.github.trevarj.motd.data.repo.NetworkIgnoreRepository
 import io.github.trevarj.motd.data.repo.NoopNetworkIgnoreRepository
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
 import io.github.trevarj.motd.irc.proto.IrcMessage
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchDuration
+import io.github.trevarj.motd.service.ChannelWatchState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.RosterLoadState
 import io.github.trevarj.motd.ui.chat.ComposerDraftStore
@@ -32,6 +36,7 @@ import io.github.trevarj.motd.ui.chat.WhoisInfo
 import io.github.trevarj.motd.ui.chat.parseWhois
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -39,7 +44,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -138,6 +145,48 @@ sealed interface ChannelInfoOperationEvent {
     data object LeaveAccepted : ChannelInfoOperationEvent
 }
 
+/** What the channel-info notifications row reports. */
+sealed interface ChannelNotifyLevel {
+    data object MentionsOnly : ChannelNotifyLevel
+
+    data object Muted : ChannelNotifyLevel
+
+    data class All(
+        val minutesLeft: Int,
+        val overridesMute: Boolean,
+    ) : ChannelNotifyLevel
+}
+
+internal const val NOTIFY_LEVEL_TICK_MS = 30_000L
+
+/** A live watch on this buffer wins over the mute; remaining time rounds up to a whole minute. */
+internal fun deriveNotifyLevel(
+    muted: Boolean,
+    watch: ChannelWatchState?,
+    bufferId: Long,
+    nowMillis: Long,
+): ChannelNotifyLevel {
+    val active = watch?.takeIf { it.bufferId == bufferId && it.expiresAt > nowMillis }
+    return when {
+        active != null -> {
+            ChannelNotifyLevel.All(
+                minutesLeft = ceilMinutes(active.expiresAt - nowMillis),
+                overridesMute = muted,
+            )
+        }
+
+        muted -> {
+            ChannelNotifyLevel.Muted
+        }
+
+        else -> {
+            ChannelNotifyLevel.MentionsOnly
+        }
+    }
+}
+
+private fun ceilMinutes(remainingMs: Long): Int = ((remainingMs + 59_999L) / 60_000L).toInt().coerceAtLeast(1)
+
 internal data class RosterPresentation(
     val memberCount: Int?,
     val hasStaleMembers: Boolean,
@@ -165,6 +214,8 @@ class ChannelInfoViewModel
         private val networkIdentityDao: NetworkIdentityDao,
         private val networkIgnoreRepository: NetworkIgnoreRepository = NoopNetworkIgnoreRepository,
         private val avatarController: AvatarController = NoopAvatarController,
+        private val channelWatch: ChannelWatch = ChannelWatch.Noop,
+        private val clock: AppClock = AppClock(System::currentTimeMillis),
     ) : ViewModel() {
         private val bufferIdFlow = MutableStateFlow<Long?>(null)
         val presenceStates = connectionManager.presenceStates
@@ -326,6 +377,41 @@ class ChannelInfoViewModel
                 started = SharingStarted.WhileSubscribed(5_000),
                 initialValue = ChannelInfoUiState(),
             )
+
+        /**
+         * Notification level for this channel: an active watch outranks the buffer mute, which
+         * outranks the default mentions-only. Re-emits on a tick so the remaining minutes stay live.
+         */
+        val notifyLevel: StateFlow<ChannelNotifyLevel> =
+            combine(bufferIdFlow, bufferFlow, channelWatch.state) { id, buffer, watch ->
+                Triple(id, buffer?.muted == true, watch)
+            }.flatMapLatest { (id, muted, watch) ->
+                val bufferId = id
+                if (bufferId == null) {
+                    flowOf<ChannelNotifyLevel>(ChannelNotifyLevel.MentionsOnly)
+                } else {
+                    flow {
+                        while (true) {
+                            val level = deriveNotifyLevel(muted, watch, bufferId, clock.nowMillis())
+                            emit(level)
+                            if (level !is ChannelNotifyLevel.All) break
+                            delay(NOTIFY_LEVEL_TICK_MS)
+                        }
+                    }
+                }
+            }.distinctUntilChanged()
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = ChannelNotifyLevel.MentionsOnly,
+                )
+
+        fun startWatch(duration: ChannelWatchDuration) =
+            viewModelScope.launch {
+                bufferIdFlow.value?.let { channelWatch.start(it, duration.millis) }
+            }
+
+        fun stopWatch() = viewModelScope.launch { channelWatch.stop() }
 
         fun retryMembers() =
             viewModelScope.launch {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
@@ -30,6 +30,7 @@ import io.github.trevarj.motd.service.ChannelWatchDuration
 import io.github.trevarj.motd.service.ChannelWatchState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.RosterLoadState
+import io.github.trevarj.motd.service.isForever
 import io.github.trevarj.motd.ui.chat.ComposerDraftStore
 import io.github.trevarj.motd.ui.chat.NickSheetState
 import io.github.trevarj.motd.ui.chat.WhoisInfo
@@ -151,8 +152,9 @@ sealed interface ChannelNotifyLevel {
 
     data object Muted : ChannelNotifyLevel
 
+    /** [minutesLeft] null means the watch never expires. */
     data class All(
-        val minutesLeft: Int,
+        val minutesLeft: Int?,
         val overridesMute: Boolean,
     ) : ChannelNotifyLevel
 }
@@ -170,7 +172,7 @@ internal fun deriveNotifyLevel(
     return when {
         active != null -> {
             ChannelNotifyLevel.All(
-                minutesLeft = ceilMinutes(active.expiresAt - nowMillis),
+                minutesLeft = if (active.isForever) null else ceilMinutes(active.expiresAt - nowMillis),
                 overridesMute = muted,
             )
         }
@@ -394,7 +396,7 @@ class ChannelInfoViewModel
                         while (true) {
                             val level = deriveNotifyLevel(muted, watch, bufferId, clock.nowMillis())
                             emit(level)
-                            if (level !is ChannelNotifyLevel.All) break
+                            if (level !is ChannelNotifyLevel.All || level.minutesLeft == null) break
                             delay(NOTIFY_LEVEL_TICK_MS)
                         }
                     }

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoViewModel.kt
@@ -385,8 +385,8 @@ class ChannelInfoViewModel
          * outranks the default mentions-only. Re-emits on a tick so the remaining minutes stay live.
          */
         val notifyLevel: StateFlow<ChannelNotifyLevel> =
-            combine(bufferIdFlow, bufferFlow, channelWatch.state) { id, buffer, watch ->
-                Triple(id, buffer?.muted == true, watch)
+            combine(bufferFlow, channelWatch.state) { buffer, watch ->
+                Triple(buffer?.id, buffer?.muted == true, watch)
             }.flatMapLatest { (id, muted, watch) ->
                 val bufferId = id
                 if (bufferId == null) {
@@ -410,7 +410,7 @@ class ChannelInfoViewModel
 
         fun startWatch(duration: ChannelWatchDuration) =
             viewModelScope.launch {
-                bufferIdFlow.value?.let { channelWatch.start(it, duration.millis) }
+                state.value.buffer?.let { channelWatch.start(it.id, duration.millis) }
             }
 
         fun stopWatch() = viewModelScope.launch { channelWatch.stop() }

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
@@ -66,7 +66,7 @@ import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Notifications
-import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.material.icons.outlined.NotificationsActive
 import androidx.compose.material.icons.outlined.PeopleOutline
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.ViewAgenda
@@ -199,12 +199,12 @@ import io.github.trevarj.motd.ui.components.AudioMiniPlayer
 import io.github.trevarj.motd.ui.components.AutocompletePanel
 import io.github.trevarj.motd.ui.components.Avatar
 import io.github.trevarj.motd.ui.components.AvatarEditorSheet
+import io.github.trevarj.motd.ui.components.ChannelWatchDialog
 import io.github.trevarj.motd.ui.components.Composer
 import io.github.trevarj.motd.ui.components.ComposerReply
 import io.github.trevarj.motd.ui.components.HistorySyncSpinner
 import io.github.trevarj.motd.ui.components.WaveformScrubber
 import io.github.trevarj.motd.ui.components.avatarsHidden
-import io.github.trevarj.motd.ui.components.label
 import io.github.trevarj.motd.ui.components.typingText
 import io.github.trevarj.motd.ui.share.PendingShare
 import io.github.trevarj.motd.ui.theme.ConversationTypography
@@ -1098,6 +1098,7 @@ fun ChatContent(
     var longDraftPrompt by rememberSaveable { mutableStateOf(false) }
     var overflowOpen by rememberSaveable { mutableStateOf(false) }
     var conversationLayoutSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var watchDialogOpen by rememberSaveable { mutableStateOf(false) }
     var presenceModeSheetOpen by rememberSaveable { mutableStateOf(false) }
     var highlightMsgid by rememberSaveable { mutableStateOf<String?>(null) }
     // Global fool expand/collapse toggle: when true every collapsed fool row in the
@@ -2280,33 +2281,24 @@ fun ChatContent(
                                 )
                             }
                             if (buffer?.type == BufferType.CHANNEL) {
-                                if (watchingThisBuffer) {
-                                    DropdownMenuItem(
-                                        modifier = Modifier.testTag("chat_watch_stop"),
-                                        text = { Text(stringResource(R.string.chat_watch_stop)) },
-                                        leadingIcon = {
-                                            Icon(Icons.Outlined.NotificationsOff, contentDescription = null)
-                                        },
-                                        onClick = {
-                                            overflowOpen = false
-                                            onStopChannelWatch()
-                                        },
-                                    )
-                                } else {
-                                    ChannelWatchDuration.entries.forEach { duration ->
-                                        DropdownMenuItem(
-                                            modifier = Modifier.testTag("chat_watch_${duration.minutes}"),
-                                            text = { Text(duration.label()) },
-                                            leadingIcon = {
-                                                Icon(Icons.Outlined.Notifications, contentDescription = null)
+                                DropdownMenuItem(
+                                    modifier = Modifier.testTag("chat_watch"),
+                                    text = { Text(stringResource(R.string.channelinfo_notifications)) },
+                                    leadingIcon = {
+                                        Icon(
+                                            if (watchingThisBuffer) {
+                                                Icons.Outlined.NotificationsActive
+                                            } else {
+                                                Icons.Outlined.Notifications
                                             },
-                                            onClick = {
-                                                overflowOpen = false
-                                                onStartChannelWatch(duration)
-                                            },
+                                            contentDescription = null,
                                         )
-                                    }
-                                }
+                                    },
+                                    onClick = {
+                                        overflowOpen = false
+                                        watchDialogOpen = true
+                                    },
+                                )
                             }
                             DropdownMenuItem(
                                 modifier = Modifier.testTag("chat_layout_menu"),
@@ -3080,6 +3072,15 @@ fun ChatContent(
                 conversationLayoutSheetOpen = false
             },
             onDismiss = { conversationLayoutSheetOpen = false },
+        )
+    }
+    if (watchDialogOpen) {
+        ChannelWatchDialog(
+            watchActive = watchingThisBuffer,
+            onStart = onStartChannelWatch,
+            onStop = onStopChannelWatch,
+            onDismiss = { watchDialogOpen = false },
+            tagPrefix = "chat",
         )
     }
 }

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
@@ -65,6 +65,8 @@ import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.PeopleOutline
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.ViewAgenda
@@ -190,6 +192,9 @@ import io.github.trevarj.motd.irc.client.canSendReactionTags
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.irc.format.plainIrcText
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
+import io.github.trevarj.motd.service.CHANNEL_WATCH_15_MS
+import io.github.trevarj.motd.service.CHANNEL_WATCH_30_MS
+import io.github.trevarj.motd.service.CHANNEL_WATCH_60_MS
 import io.github.trevarj.motd.service.HistorySyncStatus
 import io.github.trevarj.motd.ui.channelinfo.ModeCatalog
 import io.github.trevarj.motd.ui.components.AudioMiniPlayer
@@ -347,6 +352,7 @@ fun ChatScreen(
     val memberNicks by viewModel.memberNicks.collectAsStateWithLifecycle()
     val knownNicks by viewModel.knownNicks.collectAsStateWithLifecycle()
     val joinedChannels by viewModel.joinedChannels.collectAsStateWithLifecycle()
+    val activeWatch by viewModel.activeWatch.collectAsStateWithLifecycle()
     val voiceState by voiceViewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val voicePermissionGate =
@@ -498,6 +504,9 @@ fun ChatScreen(
             viewModel.ensureMembersObserved()
             inviteChannelOpen = true
         },
+        watchingThisBuffer = activeWatch?.bufferId == state.buffer?.id,
+        onStartChannelWatch = viewModel::startChannelWatch,
+        onStopChannelWatch = viewModel::stopChannelWatch,
         nickNormalizer = nickNormalizer,
         onSubmit = { raw -> viewModel.submit(raw, onOpenBuffer = onOpenBuffer, onOpenChannelList = onOpenChannelList) },
         onTyping = viewModel::sendTyping,
@@ -897,6 +906,9 @@ fun ChatContent(
     accountSetupReminder: Boolean = false,
     onAccountSetup: () -> Unit = {},
     onDismissAccountSetup: () -> Unit = {},
+    watchingThisBuffer: Boolean = false,
+    onStartChannelWatch: (Long) -> Unit = {},
+    onStopChannelWatch: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val autoFollow = remember { AutoFollowTracker(items.itemCount) }
@@ -2267,6 +2279,55 @@ fun ChatContent(
                                         onInviteUser()
                                     },
                                 )
+                            }
+                            if (buffer?.type == BufferType.CHANNEL) {
+                                if (watchingThisBuffer) {
+                                    DropdownMenuItem(
+                                        modifier = Modifier.testTag("chat_watch_stop"),
+                                        text = { Text(stringResource(R.string.chat_watch_stop)) },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.NotificationsOff, contentDescription = null)
+                                        },
+                                        onClick = {
+                                            overflowOpen = false
+                                            onStopChannelWatch()
+                                        },
+                                    )
+                                } else {
+                                    DropdownMenuItem(
+                                        modifier = Modifier.testTag("chat_watch_15"),
+                                        text = { Text(stringResource(R.string.chat_watch_15)) },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
+                                        },
+                                        onClick = {
+                                            overflowOpen = false
+                                            onStartChannelWatch(CHANNEL_WATCH_15_MS)
+                                        },
+                                    )
+                                    DropdownMenuItem(
+                                        modifier = Modifier.testTag("chat_watch_30"),
+                                        text = { Text(stringResource(R.string.chat_watch_30)) },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
+                                        },
+                                        onClick = {
+                                            overflowOpen = false
+                                            onStartChannelWatch(CHANNEL_WATCH_30_MS)
+                                        },
+                                    )
+                                    DropdownMenuItem(
+                                        modifier = Modifier.testTag("chat_watch_60"),
+                                        text = { Text(stringResource(R.string.chat_watch_60)) },
+                                        leadingIcon = {
+                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
+                                        },
+                                        onClick = {
+                                            overflowOpen = false
+                                            onStartChannelWatch(CHANNEL_WATCH_60_MS)
+                                        },
+                                    )
+                                }
                             }
                             DropdownMenuItem(
                                 modifier = Modifier.testTag("chat_layout_menu"),

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatScreen.kt
@@ -192,9 +192,7 @@ import io.github.trevarj.motd.irc.client.canSendReactionTags
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.irc.format.plainIrcText
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
-import io.github.trevarj.motd.service.CHANNEL_WATCH_15_MS
-import io.github.trevarj.motd.service.CHANNEL_WATCH_30_MS
-import io.github.trevarj.motd.service.CHANNEL_WATCH_60_MS
+import io.github.trevarj.motd.service.ChannelWatchDuration
 import io.github.trevarj.motd.service.HistorySyncStatus
 import io.github.trevarj.motd.ui.channelinfo.ModeCatalog
 import io.github.trevarj.motd.ui.components.AudioMiniPlayer
@@ -206,6 +204,7 @@ import io.github.trevarj.motd.ui.components.ComposerReply
 import io.github.trevarj.motd.ui.components.HistorySyncSpinner
 import io.github.trevarj.motd.ui.components.WaveformScrubber
 import io.github.trevarj.motd.ui.components.avatarsHidden
+import io.github.trevarj.motd.ui.components.label
 import io.github.trevarj.motd.ui.components.typingText
 import io.github.trevarj.motd.ui.share.PendingShare
 import io.github.trevarj.motd.ui.theme.ConversationTypography
@@ -907,7 +906,7 @@ fun ChatContent(
     onAccountSetup: () -> Unit = {},
     onDismissAccountSetup: () -> Unit = {},
     watchingThisBuffer: Boolean = false,
-    onStartChannelWatch: (Long) -> Unit = {},
+    onStartChannelWatch: (ChannelWatchDuration) -> Unit = {},
     onStopChannelWatch: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
@@ -2294,39 +2293,19 @@ fun ChatContent(
                                         },
                                     )
                                 } else {
-                                    DropdownMenuItem(
-                                        modifier = Modifier.testTag("chat_watch_15"),
-                                        text = { Text(stringResource(R.string.chat_watch_15)) },
-                                        leadingIcon = {
-                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
-                                        },
-                                        onClick = {
-                                            overflowOpen = false
-                                            onStartChannelWatch(CHANNEL_WATCH_15_MS)
-                                        },
-                                    )
-                                    DropdownMenuItem(
-                                        modifier = Modifier.testTag("chat_watch_30"),
-                                        text = { Text(stringResource(R.string.chat_watch_30)) },
-                                        leadingIcon = {
-                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
-                                        },
-                                        onClick = {
-                                            overflowOpen = false
-                                            onStartChannelWatch(CHANNEL_WATCH_30_MS)
-                                        },
-                                    )
-                                    DropdownMenuItem(
-                                        modifier = Modifier.testTag("chat_watch_60"),
-                                        text = { Text(stringResource(R.string.chat_watch_60)) },
-                                        leadingIcon = {
-                                            Icon(Icons.Outlined.Notifications, contentDescription = null)
-                                        },
-                                        onClick = {
-                                            overflowOpen = false
-                                            onStartChannelWatch(CHANNEL_WATCH_60_MS)
-                                        },
-                                    )
+                                    ChannelWatchDuration.entries.forEach { duration ->
+                                        DropdownMenuItem(
+                                            modifier = Modifier.testTag("chat_watch_${duration.minutes}"),
+                                            text = { Text(duration.label()) },
+                                            leadingIcon = {
+                                                Icon(Icons.Outlined.Notifications, contentDescription = null)
+                                            },
+                                            onClick = {
+                                                overflowOpen = false
+                                                onStartChannelWatch(duration)
+                                            },
+                                        )
+                                    }
                                 }
                             }
                             DropdownMenuItem(

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
@@ -294,7 +294,7 @@ class ChatViewModel
         val activeWatch: StateFlow<ChannelWatchState?> = channelWatch.state
 
         fun startChannelWatch(duration: ChannelWatchDuration) {
-            viewModelScope.launch { channelWatch.start(bufferId, duration.millis) }
+            viewModelScope.launch { channelWatch.start(operationalBufferId.value, duration.millis) }
         }
 
         fun stopChannelWatch() {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
@@ -64,6 +64,8 @@ import io.github.trevarj.motd.irc.client.canSendReactionTags
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
 import io.github.trevarj.motd.irc.proto.IrcMessage
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.ForegroundBufferTracker
 import io.github.trevarj.motd.service.HistoryResyncController
@@ -270,6 +272,7 @@ class ChatViewModel
         // Fail-closed default for hand-built call sites: the global image/video stacks cannot be
         // routed through a network proxy, so unknown transport policy means no direct media fetches.
         private val directMediaPolicy: DirectMediaPolicy = DirectMediaPolicy { false },
+        private val channelWatch: ChannelWatch = ChannelWatch.Noop,
         contentPreviewPrefs: ContentPreviewPrefs,
     ) : ViewModel() {
         val contentPreviews: StateFlow<ContentPreviewConfig> =
@@ -286,6 +289,17 @@ class ChatViewModel
 
         private val route: ChatRoute = savedStateHandle.toRoute<ChatRoute>()
         val bufferId: Long = route.bufferId
+
+        val activeWatch: StateFlow<ChannelWatchState?> =
+            channelWatch.state.stateIn(viewModelScope, SharingStarted.Eagerly, channelWatch.state.value)
+
+        fun startChannelWatch(durationMs: Long) {
+            viewModelScope.launch { channelWatch.start(bufferId, durationMs) }
+        }
+
+        fun stopChannelWatch() {
+            viewModelScope.launch { channelWatch.stop() }
+        }
 
         /** This screen was opened by a deep link/notification tap rather than by a plain room open. */
         private val routeHasDeepJump: Boolean =

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModel.kt
@@ -65,6 +65,7 @@ import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
 import io.github.trevarj.motd.irc.proto.IrcMessage
 import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchDuration
 import io.github.trevarj.motd.service.ChannelWatchState
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.ForegroundBufferTracker
@@ -290,11 +291,10 @@ class ChatViewModel
         private val route: ChatRoute = savedStateHandle.toRoute<ChatRoute>()
         val bufferId: Long = route.bufferId
 
-        val activeWatch: StateFlow<ChannelWatchState?> =
-            channelWatch.state.stateIn(viewModelScope, SharingStarted.Eagerly, channelWatch.state.value)
+        val activeWatch: StateFlow<ChannelWatchState?> = channelWatch.state
 
-        fun startChannelWatch(durationMs: Long) {
-            viewModelScope.launch { channelWatch.start(bufferId, durationMs) }
+        fun startChannelWatch(duration: ChannelWatchDuration) {
+            viewModelScope.launch { channelWatch.start(bufferId, duration.millis) }
         }
 
         fun stopChannelWatch() {

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchDialog.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchDialog.kt
@@ -2,6 +2,8 @@ package io.github.trevarj.motd.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material3.AlertDialog
@@ -38,7 +40,7 @@ fun ChannelWatchDialog(
                 .testTag("${tagPrefix}_notify_dialog"),
         title = { Text(stringResource(R.string.channelinfo_notifications)) },
         text = {
-            Column {
+            Column(Modifier.verticalScroll(rememberScrollState())) {
                 ChannelWatchDuration.entries.forEach { duration ->
                     ListItem(
                         headlineContent = { Text(duration.label()) },

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchDialog.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchDialog.kt
@@ -1,0 +1,78 @@
+package io.github.trevarj.motd.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import io.github.trevarj.motd.R
+import io.github.trevarj.motd.service.ChannelWatchDuration
+
+/** Watch-duration picker shared by channel info and the chat overflow; [tagPrefix] scopes the tags. */
+@Composable
+fun ChannelWatchDialog(
+    watchActive: Boolean,
+    onStart: (ChannelWatchDuration) -> Unit,
+    onStop: () -> Unit,
+    onDismiss: () -> Unit,
+    tagPrefix: String,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        // A dialog window does not inherit the root's tag mapping, so opt it in here.
+        modifier =
+            Modifier
+                .semantics { testTagsAsResourceId = true }
+                .testTag("${tagPrefix}_notify_dialog"),
+        title = { Text(stringResource(R.string.channelinfo_notifications)) },
+        text = {
+            Column {
+                ChannelWatchDuration.entries.forEach { duration ->
+                    ListItem(
+                        headlineContent = { Text(duration.label()) },
+                        leadingContent = { Icon(duration.icon, contentDescription = null) },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        modifier =
+                            Modifier
+                                .testTag("${tagPrefix}_watch_${duration.tag}")
+                                .clickable {
+                                    onStart(duration)
+                                    onDismiss()
+                                },
+                    )
+                }
+                if (watchActive) {
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.chat_watch_stop)) },
+                        leadingContent = { Icon(Icons.Outlined.NotificationsOff, contentDescription = null) },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        modifier =
+                            Modifier
+                                .testTag("${tagPrefix}_watch_stop")
+                                .clickable {
+                                    onStop()
+                                    onDismiss()
+                                },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchLabels.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchLabels.kt
@@ -1,0 +1,19 @@
+package io.github.trevarj.motd.ui.components
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import io.github.trevarj.motd.R
+import io.github.trevarj.motd.service.ChannelWatchDuration
+
+/** Single source for the watch-duration wording; both watch entry points read it. */
+@StringRes
+fun ChannelWatchDuration.labelRes(): Int =
+    when (this) {
+        ChannelWatchDuration.MIN_15 -> R.string.chat_watch_15
+        ChannelWatchDuration.MIN_30 -> R.string.chat_watch_30
+        ChannelWatchDuration.MIN_60 -> R.string.chat_watch_60
+    }
+
+@Composable
+fun ChannelWatchDuration.label(): String = stringResource(labelRes())

--- a/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchLabels.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/ui/components/ChannelWatchLabels.kt
@@ -1,7 +1,13 @@
 package io.github.trevarj.motd.ui.components
 
 import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AllInclusive
+import androidx.compose.material.icons.outlined.HourglassBottom
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.HourglassFull
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import io.github.trevarj.motd.R
 import io.github.trevarj.motd.service.ChannelWatchDuration
@@ -13,7 +19,18 @@ fun ChannelWatchDuration.labelRes(): Int =
         ChannelWatchDuration.MIN_15 -> R.string.chat_watch_15
         ChannelWatchDuration.MIN_30 -> R.string.chat_watch_30
         ChannelWatchDuration.MIN_60 -> R.string.chat_watch_60
+        ChannelWatchDuration.FOREVER -> R.string.chat_watch_forever
     }
 
 @Composable
 fun ChannelWatchDuration.label(): String = stringResource(labelRes())
+
+/** Hourglass fill tracks the duration; forever gets the infinity mark. */
+val ChannelWatchDuration.icon: ImageVector
+    get() =
+        when (this) {
+            ChannelWatchDuration.MIN_15 -> Icons.Outlined.HourglassEmpty
+            ChannelWatchDuration.MIN_30 -> Icons.Outlined.HourglassBottom
+            ChannelWatchDuration.MIN_60 -> Icons.Outlined.HourglassFull
+            ChannelWatchDuration.FOREVER -> Icons.Outlined.AllInclusive
+        }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,6 +602,7 @@
     <string name="chat_watch_15">Notify on all for 15 minutes</string>
     <string name="chat_watch_30">Notify on all for 30 minutes</string>
     <string name="chat_watch_60">Notify on all for 1 hour</string>
+    <string name="chat_watch_forever">Notify on all forever</string>
     <string name="chat_watch_stop">Stop notifying on all messages</string>
     <string name="notification_watch_ended">No longer notifying on every message in %1$s</string>
     <string name="notification_watch_ended_title">Watch ended</string>
@@ -610,6 +611,8 @@
     <string name="channelinfo_notify_muted">Muted</string>
     <string name="channelinfo_notify_all">All messages, %1$d min left</string>
     <string name="channelinfo_notify_overrides_mute">All messages, %1$d min left (overrides mute)</string>
+    <string name="channelinfo_notify_all_forever">All messages</string>
+    <string name="channelinfo_notify_all_forever_overrides_mute">All messages (overrides mute)</string>
     <string name="chat_layout_title">Conversation layout</string>
     <string name="chat_layout_use_global">Use global setting</string>
     <string name="chat_layout_use_server_default">Server default (Two-line)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -599,6 +599,11 @@
     <string name="settings_density_compact">Compact</string>
     <string name="settings_density_comfortable">Comfortable</string>
     <string name="settings_density_two_line">Two-line</string>
+    <string name="chat_watch_15">Notify on all for 15 minutes</string>
+    <string name="chat_watch_30">Notify on all for 30 minutes</string>
+    <string name="chat_watch_60">Notify on all for 1 hour</string>
+    <string name="chat_watch_stop">Stop notifying on all messages</string>
+    <string name="notification_watch_ended">No longer notifying on every message in %1$s</string>
     <string name="chat_layout_title">Conversation layout</string>
     <string name="chat_layout_use_global">Use global setting</string>
     <string name="chat_layout_use_server_default">Server default (Two-line)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -604,6 +604,12 @@
     <string name="chat_watch_60">Notify on all for 1 hour</string>
     <string name="chat_watch_stop">Stop notifying on all messages</string>
     <string name="notification_watch_ended">No longer notifying on every message in %1$s</string>
+    <string name="notification_watch_ended_title">Watch ended</string>
+    <string name="channelinfo_notifications">Notifications</string>
+    <string name="channelinfo_notify_mentions">Mentions only</string>
+    <string name="channelinfo_notify_muted">Muted</string>
+    <string name="channelinfo_notify_all">All messages, %1$d min left</string>
+    <string name="channelinfo_notify_overrides_mute">All messages, %1$d min left (overrides mute)</string>
     <string name="chat_layout_title">Conversation layout</string>
     <string name="chat_layout_use_global">Use global setting</string>
     <string name="chat_layout_use_server_default">Server default (Two-line)</string>

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/db/AllMigrationsTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/db/AllMigrationsTest.kt
@@ -6,6 +6,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -166,7 +167,7 @@ class AllMigrationsTest {
         val migrated =
             Room
                 .databaseBuilder(context, MotdDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38)
+                .addMigrations(MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39)
                 .build()
         try {
             migrated.openHelper.writableDatabase
@@ -236,7 +237,7 @@ class AllMigrationsTest {
         val migrated =
             Room
                 .databaseBuilder(context, MotdDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38)
+                .addMigrations(MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39)
                 .build()
         try {
             val sqlite = migrated.openHelper.writableDatabase
@@ -310,7 +311,7 @@ class AllMigrationsTest {
         val migrated =
             Room
                 .databaseBuilder(context, MotdDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38)
+                .addMigrations(MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39)
                 .build()
         try {
             val sqlite = migrated.openHelper.writableDatabase
@@ -387,7 +388,7 @@ class AllMigrationsTest {
         val migrated =
             Room
                 .databaseBuilder(context, MotdDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38)
+                .addMigrations(MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36, MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39)
                 .build()
         try {
             val sqlite = migrated.openHelper.writableDatabase
@@ -421,6 +422,95 @@ class AllMigrationsTest {
             migrated.close()
         }
     }
+
+    @Test
+    fun migrateVersion38ToCurrent_preservesHistoryWithoutInventingWatchEligibility() =
+        runTest {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            context.deleteDatabase(DB_NAME)
+            legacyHelper =
+                FrameworkSQLiteOpenHelperFactory().create(
+                    SupportSQLiteOpenHelper.Configuration
+                        .builder(context)
+                        .name(DB_NAME)
+                        .callback(
+                            object : SupportSQLiteOpenHelper.Callback(38) {
+                                override fun onCreate(db: SupportSQLiteDatabase) = createExportedVersion(db, 38)
+
+                                override fun onUpgrade(
+                                    db: SupportSQLiteDatabase,
+                                    old: Int,
+                                    new: Int,
+                                ) = Unit
+                            },
+                        ).build(),
+                )
+            legacyHelper!!.writableDatabase.apply {
+                execSQL(
+                    """INSERT INTO networks
+                        (id, name, role, host, port, tls, nick, username, realname, saslMechanism,
+                         autoConnect, ordering, restoreAutoConnect)
+                        VALUES (1, 'libera', 'DIRECT', 'irc.libera.chat', 6697, 1, 'me', 'me', 'Me',
+                                'NONE', 1, 0, 1)""",
+                )
+                execSQL(
+                    """INSERT INTO buffers
+                        (id, networkId, name, displayName, type, joined, membershipCycle, pinned,
+                         muted, archived, ordering, historyComplete, dismissed)
+                        VALUES (1, 1, '#motd', '#motd', 'CHANNEL', 1, 0, 0, 1, 0, 0, 0, 0)""",
+                )
+                execSQL(
+                    """INSERT INTO messages
+                        (id, bufferId, serverTime, sender, normalizedActor, kind, text, isSelf,
+                         hasMention, failed, dedupKey, serverTimeAuthoritative, timelineOrder,
+                         timelineOrderConfirmed, timeProvenance, notificationHandled,
+                         notificationClaimed, soundHandled)
+                        VALUES (1, 1, 1000, 'alice', 'alice', 'PRIVMSG', 'ordinary', 0, 0, 0, 'm1',
+                                1, 1, 0, 'SERVER_TAG', 0, 0, 0),
+                               (2, 1, 2000, 'alice', 'alice', 'PRIVMSG', 'me: mention', 0, 1, 0, 'm2',
+                                1, 2, 0, 'SERVER_TAG', 0, 0, 0)""",
+                )
+                execSQL(
+                    """INSERT INTO event_observations
+                        (networkId, timelineEventId, origin, receiveOrder, timeProvenance,
+                         semanticFingerprint, observedAt)
+                        SELECT 1, id, 'LIVE', id, 'SERVER_TAG', X'01', serverTime FROM messages""",
+                )
+            }
+            legacyHelper!!.close()
+            legacyHelper = null
+
+            val migrated =
+                Room
+                    .databaseBuilder(context, MotdDatabase::class.java, DB_NAME)
+                    .addMigrations(*ALL_MIGRATIONS)
+                    .build()
+            try {
+                assertEquals(
+                    listOf("ordinary", "me: mention"),
+                    migrated.messageDao().historyRowsForMerge(1).map { it.text },
+                )
+                assertEquals(
+                    listOf("me: mention"),
+                    migrated.canonicalTimelineDao().pendingNotifications(10).map { it.text },
+                )
+                assertEquals(
+                    listOf("me: mention"),
+                    migrated
+                        .messageDao()
+                        .recentNotifiable(
+                            bufferId = 1,
+                            afterTime = Long.MIN_VALUE,
+                            afterEventId = Long.MIN_VALUE,
+                            queryRoom = false,
+                            excludeEventId = -1,
+                            limit = 10,
+                        ).map { it.text },
+                )
+            } finally {
+                migrated.close()
+            }
+        }
 
     /**
      * The registered array is what `DbModule` hands Room on a real device, so a hop missing from it
@@ -456,10 +546,10 @@ class AllMigrationsTest {
         const val DB_NAME = "all-migrations-test.db"
 
         /**
-         * Mirrors `version = 38` on `@Database`. Room's annotation is CLASS-retained, so the
+         * Mirrors `version = 39` on `@Database`. Room's annotation is CLASS-retained, so the
          * declared version cannot be read reflectively; the exported schema JSON is the runtime
          * witness for it instead.
          */
-        const val DECLARED_VERSION = 38
+        const val DECLARED_VERSION = 39
     }
 }

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
@@ -8,6 +8,7 @@ import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MotdDatabase
 import io.github.trevarj.motd.data.db.NetworkEntity
 import io.github.trevarj.motd.data.db.NetworkRole
+import io.github.trevarj.motd.data.db.TimelineEventId
 import io.github.trevarj.motd.irc.event.IrcEvent
 import io.github.trevarj.motd.irc.event.MessageContext
 import io.github.trevarj.motd.irc.proto.Prefix
@@ -27,6 +28,7 @@ import org.robolectric.RobolectricTestRunner
 class EventProcessorChannelWatchTest {
     private class RecordingNotifier : MessageNotifier {
         val incoming = mutableListOf<IrcEvent.ChatMessage>()
+        val watchedFlags = mutableListOf<Boolean>()
 
         override suspend fun onIncoming(
             networkId: Long,
@@ -36,6 +38,19 @@ class EventProcessorChannelWatchTest {
             message: IrcEvent.ChatMessage,
         ) {
             incoming += message
+        }
+
+        override suspend fun onCanonicalIncoming(
+            networkId: Long,
+            bufferId: Long,
+            type: BufferType,
+            hasMention: Boolean,
+            eventId: TimelineEventId,
+            message: IrcEvent.ChatMessage,
+            watched: Boolean,
+        ) {
+            watchedFlags += watched
+            onIncoming(networkId, bufferId, type, hasMention, message)
         }
     }
 
@@ -117,6 +132,17 @@ class EventProcessorChannelWatchTest {
             watched.onRegistered(networkId, "me", emptyMap())
             watched.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "still hello", "m2"))
             assertEquals(1, notifier.incoming.size)
+            assertEquals(listOf(true), notifier.watchedFlags)
+        }
+
+    @Test
+    fun `mention on an unwatched channel notifies without the watched flag`() =
+        runTest {
+            val idle = processor()
+            idle.onRegistered(networkId, "me", emptyMap())
+            idle.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "me: ping", "m3"))
+            assertEquals(1, notifier.incoming.size)
+            assertEquals(listOf(false), notifier.watchedFlags)
         }
 
     @Test

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
@@ -1,0 +1,148 @@
+package io.github.trevarj.motd.data.sync
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import io.github.trevarj.motd.data.db.BufferEntity
+import io.github.trevarj.motd.data.db.BufferType
+import io.github.trevarj.motd.data.db.MotdDatabase
+import io.github.trevarj.motd.data.db.NetworkEntity
+import io.github.trevarj.motd.data.db.NetworkRole
+import io.github.trevarj.motd.irc.event.IrcEvent
+import io.github.trevarj.motd.irc.event.MessageContext
+import io.github.trevarj.motd.irc.proto.Prefix
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EventProcessorChannelWatchTest {
+    private class RecordingNotifier : MessageNotifier {
+        val incoming = mutableListOf<IrcEvent.ChatMessage>()
+
+        override suspend fun onIncoming(
+            networkId: Long,
+            bufferId: Long,
+            type: BufferType,
+            hasMention: Boolean,
+            message: IrcEvent.ChatMessage,
+        ) {
+            incoming += message
+        }
+    }
+
+    private class StickyWatch(
+        private val watched: Long,
+    ) : ChannelWatch {
+        override val state: StateFlow<ChannelWatchState?> =
+            MutableStateFlow(ChannelWatchState(watched, Long.MAX_VALUE))
+
+        override fun isActive(bufferId: Long): Boolean = bufferId == watched
+
+        override suspend fun start(
+            bufferId: Long,
+            durationMs: Long,
+        ) = Unit
+
+        override suspend fun stop() = Unit
+    }
+
+    private lateinit var db: MotdDatabase
+    private lateinit var notifier: RecordingNotifier
+    private var networkId = 0L
+    private var bufferId = 0L
+
+    @Before
+    fun setUp() =
+        runTest {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            db = Room.inMemoryDatabaseBuilder(context, MotdDatabase::class.java).allowMainThreadQueries().build()
+            notifier = RecordingNotifier()
+            networkId =
+                db.networkDao().insert(
+                    NetworkEntity(
+                        name = "libera",
+                        role = NetworkRole.DIRECT,
+                        host = "h",
+                        port = 6697,
+                        nick = "me",
+                        username = "me",
+                        realname = "Me",
+                    ),
+                )
+            bufferId =
+                db.bufferDao().insert(
+                    BufferEntity(networkId = networkId, name = "#chan", displayName = "#chan", type = BufferType.CHANNEL),
+                )
+        }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun processor(watch: ChannelWatch = ChannelWatch.Noop) = EventProcessor(db, TypingTrackerImpl(), notifier, channelWatch = watch)
+
+    private fun chat(
+        kind: IrcEvent.ChatKind,
+        text: String,
+        msgid: String,
+    ) = IrcEvent.ChatMessage(
+        ctx = MessageContext(msgid = msgid, serverTime = 1000, account = null, batchId = null, label = null),
+        kind = kind,
+        source = Prefix("alice"),
+        target = "#chan",
+        text = text,
+        isSelf = false,
+        replyToMsgid = null,
+    )
+
+    @Test
+    fun `live channel privmsg without mention notifies only while watched`() =
+        runTest {
+            val idle = processor()
+            idle.onRegistered(networkId, "me", emptyMap())
+            idle.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "hello", "m1"))
+            assertEquals(0, notifier.incoming.size)
+
+            val watched = processor(StickyWatch(bufferId))
+            watched.onRegistered(networkId, "me", emptyMap())
+            watched.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "still hello", "m2"))
+            assertEquals(1, notifier.incoming.size)
+        }
+
+    @Test
+    fun `watched channel action notifies without a mention`() =
+        runTest {
+            val watched = processor(StickyWatch(bufferId))
+            watched.onRegistered(networkId, "me", emptyMap())
+            watched.process(networkId, chat(IrcEvent.ChatKind.ACTION, "waves", "a1"))
+            assertEquals(1, notifier.incoming.size)
+        }
+
+    @Test
+    fun `watched channel notice does not notify without a mention`() =
+        runTest {
+            val watched = processor(StickyWatch(bufferId))
+            watched.onRegistered(networkId, "me", emptyMap())
+            watched.process(networkId, chat(IrcEvent.ChatKind.NOTICE, "server-ish", "n1"))
+            assertEquals(0, notifier.incoming.size)
+        }
+
+    @Test
+    fun `push playback of a watched channel does not notify without a mention`() =
+        runTest {
+            val watched = processor(StickyWatch(bufferId))
+            watched.onRegistered(networkId, "me", emptyMap())
+            watched.processPush(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "replayed", "p1"))
+            assertEquals(0, notifier.incoming.size)
+        }
+}

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
@@ -9,13 +9,16 @@ import io.github.trevarj.motd.data.db.MotdDatabase
 import io.github.trevarj.motd.data.db.NetworkEntity
 import io.github.trevarj.motd.data.db.NetworkRole
 import io.github.trevarj.motd.data.db.TimelineEventId
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.irc.event.IrcEvent
 import io.github.trevarj.motd.irc.event.MessageContext
 import io.github.trevarj.motd.irc.proto.Prefix
 import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchImpl
 import io.github.trevarj.motd.service.ChannelWatchState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -60,7 +63,7 @@ class EventProcessorChannelWatchTest {
         override val state: StateFlow<ChannelWatchState?> =
             MutableStateFlow(ChannelWatchState(watched, Long.MAX_VALUE))
 
-        override fun isActive(bufferId: Long): Boolean = bufferId == watched
+        override suspend fun isActive(bufferId: Long): Boolean = bufferId == watched
 
         override suspend fun start(
             bufferId: Long,
@@ -133,6 +136,49 @@ class EventProcessorChannelWatchTest {
             watched.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "still hello", "m2"))
             assertEquals(1, notifier.incoming.size)
             assertEquals(listOf(true), notifier.watchedFlags)
+        }
+
+    @Test
+    fun `watch follows a renamed source into the canonical channel`() =
+        runTest {
+            val buffers = db.bufferDao()
+            val sourceId =
+                buffers.insert(
+                    BufferEntity(networkId = networkId, name = "#old", displayName = "#old", type = BufferType.CHANNEL),
+                )
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { 0 },
+                    onExpired = {},
+                    resolveBufferId = buffers::canonicalId,
+                    observeBufferId = { id -> buffers.observe(id).map { it?.id } },
+                )
+            val watched = processor(watch)
+            watched.onRegistered(networkId, "me", emptyMap())
+            watch.start(sourceId, null)
+
+            watched.process(
+                networkId,
+                IrcEvent.ChannelRenamed(
+                    ctx = MessageContext(msgid = "rename-1", serverTime = 999, account = null, batchId = null, label = null),
+                    actor = "oper",
+                    oldName = "#old",
+                    newName = "#chan",
+                    reason = "moving",
+                ),
+            )
+            assertEquals(bufferId, buffers.canonicalId(sourceId))
+
+            watched.process(networkId, chat(IrcEvent.ChatKind.PRIVMSG, "hello", "first-after-rename"))
+
+            assertEquals(listOf(true), notifier.watchedFlags)
+            assertEquals(
+                "first-after-rename",
+                notifier.incoming
+                    .single()
+                    .ctx.msgid,
+            )
         }
 
     @Test

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/EventProcessorChannelWatchTest.kt
@@ -64,7 +64,7 @@ class EventProcessorChannelWatchTest {
 
         override suspend fun start(
             bufferId: Long,
-            durationMs: Long,
+            durationMs: Long?,
         ) = Unit
 
         override suspend fun stop() = Unit

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/ShouldNotifyIncomingTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/ShouldNotifyIncomingTest.kt
@@ -1,0 +1,38 @@
+package io.github.trevarj.motd.data.sync
+
+import io.github.trevarj.motd.data.db.BufferType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShouldNotifyIncomingTest {
+    @Test
+    fun `query always notifies`() {
+        assertTrue(shouldNotifyIncoming(BufferType.QUERY, hasMention = false, consoleNotice = false, watchedChat = false))
+    }
+
+    @Test
+    fun `channel mention notifies`() {
+        assertTrue(shouldNotifyIncoming(BufferType.CHANNEL, hasMention = true, consoleNotice = false, watchedChat = false))
+    }
+
+    @Test
+    fun `channel without mention stays silent`() {
+        assertFalse(shouldNotifyIncoming(BufferType.CHANNEL, hasMention = false, consoleNotice = false, watchedChat = false))
+    }
+
+    @Test
+    fun `watched channel chat notifies without a mention`() {
+        assertTrue(shouldNotifyIncoming(BufferType.CHANNEL, hasMention = false, consoleNotice = false, watchedChat = true))
+    }
+
+    @Test
+    fun `console notice notifies`() {
+        assertTrue(shouldNotifyIncoming(BufferType.SERVER, hasMention = false, consoleNotice = true, watchedChat = false))
+    }
+
+    @Test
+    fun `server buffer without console notice stays silent even when watched`() {
+        assertFalse(shouldNotifyIncoming(BufferType.SERVER, hasMention = true, consoleNotice = false, watchedChat = true))
+    }
+}

--- a/app/src/test/kotlin/io/github/trevarj/motd/fuzz/EventProcessorStateMachineFuzzTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/fuzz/EventProcessorStateMachineFuzzTest.kt
@@ -511,6 +511,7 @@ class EventProcessorStateMachineFuzzTest {
             hasMention: Boolean,
             eventId: Long,
             message: IrcEvent.ChatMessage,
+            watched: Boolean,
         ) {
             eventIds += eventId
         }

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
@@ -111,6 +111,43 @@ class ChannelWatchTest {
         }
 
     @Test
+    fun `forever watch stays active and never expires`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                )
+            watch.start(7, null)
+            assertTrue(watch.isActive(7))
+            advanceTimeBy(30L * 24 * 60 * 60 * 1000)
+            runCurrent()
+            assertTrue(watch.isActive(7))
+            assertTrue(expired.isEmpty())
+        }
+
+    @Test
+    fun `restore re-arms a forever watch`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                    load = { ChannelWatchState(7, Long.MAX_VALUE) },
+                )
+            runCurrent()
+            assertTrue(watch.isActive(7))
+            advanceTimeBy(30L * 24 * 60 * 60 * 1000)
+            runCurrent()
+            assertTrue(watch.isActive(7))
+            assertTrue(expired.isEmpty())
+        }
+
+    @Test
     fun `restore expires a stale saved watch and clears it`() =
         runTest {
             val expired = mutableListOf<Long>()

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
@@ -1,5 +1,6 @@
 package io.github.trevarj.motd.service
 
+import io.github.trevarj.motd.di.AppClock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
@@ -18,7 +19,7 @@ class ChannelWatchTest {
             val watch =
                 ChannelWatchImpl(
                     scope = backgroundScope,
-                    clock = { testScheduler.currentTime },
+                    clock = AppClock { testScheduler.currentTime },
                     onExpired = { expired += it },
                 )
             watch.start(7, 1_000)
@@ -39,7 +40,7 @@ class ChannelWatchTest {
             val watch =
                 ChannelWatchImpl(
                     scope = backgroundScope,
-                    clock = { testScheduler.currentTime },
+                    clock = AppClock { testScheduler.currentTime },
                     onExpired = { expired += it },
                 )
             watch.start(7, 1_000)
@@ -57,7 +58,7 @@ class ChannelWatchTest {
             val watch =
                 ChannelWatchImpl(
                     scope = backgroundScope,
-                    clock = { testScheduler.currentTime },
+                    clock = AppClock { testScheduler.currentTime },
                     onExpired = { expired += it },
                 )
             watch.start(7, 1_000)
@@ -77,7 +78,7 @@ class ChannelWatchTest {
             val watch =
                 ChannelWatchImpl(
                     scope = backgroundScope,
-                    clock = { testScheduler.currentTime },
+                    clock = AppClock { testScheduler.currentTime },
                     onExpired = {},
                     save = { persisted += it },
                 )
@@ -87,5 +88,45 @@ class ChannelWatchTest {
             runCurrent()
             assertTrue(watch.isActive(8))
             assertEquals(8L, persisted.last()?.bufferId)
+        }
+
+    @Test
+    fun `restore re-arms an unexpired saved watch`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                    load = { ChannelWatchState(7, 1_000) },
+                )
+            runCurrent()
+            assertTrue(watch.isActive(7))
+            assertTrue(expired.isEmpty())
+            advanceTimeBy(1_000)
+            runCurrent()
+            assertEquals(listOf(7L), expired)
+            assertFalse(watch.isActive(7))
+        }
+
+    @Test
+    fun `restore expires a stale saved watch and clears it`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val persisted = mutableListOf<ChannelWatchState?>()
+            advanceTimeBy(5_000)
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                    load = { ChannelWatchState(7, 1_000) },
+                    save = { persisted += it },
+                )
+            runCurrent()
+            assertEquals(listOf(7L), expired)
+            assertFalse(watch.isActive(7))
+            assertEquals(listOf<ChannelWatchState?>(null), persisted)
         }
 }

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
@@ -2,6 +2,7 @@ package io.github.trevarj.motd.service
 
 import io.github.trevarj.motd.di.AppClock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -31,6 +32,59 @@ class ChannelWatchTest {
             runCurrent()
             assertFalse(watch.isActive(7))
             assertEquals(listOf(7L), expired)
+        }
+
+    @Test
+    fun `start resolves a stale room before persisting the watch`() =
+        runTest {
+            val persisted = mutableListOf<ChannelWatchState?>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = {},
+                    save = { persisted += it },
+                    resolveBufferId = { 8 },
+                )
+
+            watch.start(7, 1_000)
+
+            assertTrue(watch.isActive(8))
+            assertEquals(ChannelWatchState(8, 1_000), persisted.last())
+        }
+
+    @Test
+    fun `live redirect keeps eligibility before observation and preserves the expiry`() =
+        runTest {
+            var canonicalId = 7L
+            val observedId = MutableStateFlow<Long?>(canonicalId)
+            val expired = mutableListOf<Long>()
+            val persisted = mutableListOf<ChannelWatchState?>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                    save = { persisted += it },
+                    resolveBufferId = { canonicalId },
+                    observeBufferId = { observedId },
+                )
+            watch.start(7, 1_000)
+            advanceTimeBy(400)
+
+            canonicalId = 8
+            assertTrue(watch.isActive(8))
+            observedId.value = canonicalId
+            runCurrent()
+
+            assertEquals(ChannelWatchState(8, 1_000), watch.state.value)
+            assertEquals(ChannelWatchState(8, 1_000), persisted.last())
+
+            advanceTimeBy(600)
+            runCurrent()
+
+            assertFalse(watch.isActive(8))
+            assertEquals(listOf(8L), expired)
         }
 
     @Test
@@ -91,23 +145,29 @@ class ChannelWatchTest {
         }
 
     @Test
-    fun `restore re-arms an unexpired saved watch`() =
+    fun `restore resolves a redirected watch without extending its expiry`() =
         runTest {
             val expired = mutableListOf<Long>()
+            val persisted = mutableListOf<ChannelWatchState?>()
+            advanceTimeBy(400)
             val watch =
                 ChannelWatchImpl(
                     scope = backgroundScope,
                     clock = AppClock { testScheduler.currentTime },
                     onExpired = { expired += it },
                     load = { ChannelWatchState(7, 1_000) },
+                    save = { persisted += it },
+                    resolveBufferId = { 8 },
                 )
             runCurrent()
-            assertTrue(watch.isActive(7))
+            assertTrue(watch.isActive(8))
+            assertEquals(ChannelWatchState(8, 1_000), watch.state.value)
+            assertEquals(ChannelWatchState(8, 1_000), persisted.last())
             assertTrue(expired.isEmpty())
-            advanceTimeBy(1_000)
+            advanceTimeBy(600)
             runCurrent()
-            assertEquals(listOf(7L), expired)
-            assertFalse(watch.isActive(7))
+            assertEquals(listOf(8L), expired)
+            assertFalse(watch.isActive(8))
         }
 
     @Test
@@ -129,7 +189,7 @@ class ChannelWatchTest {
         }
 
     @Test
-    fun `restore re-arms a forever watch`() =
+    fun `restore resolves a forever watch`() =
         runTest {
             val expired = mutableListOf<Long>()
             val watch =
@@ -138,17 +198,18 @@ class ChannelWatchTest {
                     clock = AppClock { testScheduler.currentTime },
                     onExpired = { expired += it },
                     load = { ChannelWatchState(7, Long.MAX_VALUE) },
+                    resolveBufferId = { 8 },
                 )
             runCurrent()
-            assertTrue(watch.isActive(7))
+            assertTrue(watch.isActive(8))
             advanceTimeBy(30L * 24 * 60 * 60 * 1000)
             runCurrent()
-            assertTrue(watch.isActive(7))
+            assertTrue(watch.isActive(8))
             assertTrue(expired.isEmpty())
         }
 
     @Test
-    fun `restore expires a stale saved watch and clears it`() =
+    fun `restore expires a redirected stale saved watch and clears it`() =
         runTest {
             val expired = mutableListOf<Long>()
             val persisted = mutableListOf<ChannelWatchState?>()
@@ -160,10 +221,11 @@ class ChannelWatchTest {
                     onExpired = { expired += it },
                     load = { ChannelWatchState(7, 1_000) },
                     save = { persisted += it },
+                    resolveBufferId = { 8 },
                 )
             runCurrent()
-            assertEquals(listOf(7L), expired)
-            assertFalse(watch.isActive(7))
+            assertEquals(listOf(8L), expired)
+            assertFalse(watch.isActive(8))
             assertEquals(listOf<ChannelWatchState?>(null), persisted)
         }
 }

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/ChannelWatchTest.kt
@@ -1,0 +1,91 @@
+package io.github.trevarj.motd.service
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChannelWatchTest {
+    @Test
+    fun `start expires once`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                )
+            watch.start(7, 1_000)
+            assertTrue(watch.isActive(7))
+            advanceTimeBy(999)
+            runCurrent()
+            assertTrue(expired.isEmpty())
+            advanceTimeBy(1)
+            runCurrent()
+            assertFalse(watch.isActive(7))
+            assertEquals(listOf(7L), expired)
+        }
+
+    @Test
+    fun `stop does not expire`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                )
+            watch.start(7, 1_000)
+            watch.stop()
+            assertFalse(watch.isActive(7))
+            advanceTimeBy(5_000)
+            runCurrent()
+            assertTrue(expired.isEmpty())
+        }
+
+    @Test
+    fun `start replaces the previous watch without expiring it`() =
+        runTest {
+            val expired = mutableListOf<Long>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = { testScheduler.currentTime },
+                    onExpired = { expired += it },
+                )
+            watch.start(7, 1_000)
+            watch.start(8, 500)
+            assertFalse(watch.isActive(7))
+            assertTrue(watch.isActive(8))
+            advanceTimeBy(500)
+            runCurrent()
+            assertEquals(listOf(8L), expired)
+            assertFalse(watch.isActive(8))
+        }
+
+    @Test
+    fun `old timer does not persist-clear a replacement`() =
+        runTest {
+            val persisted = mutableListOf<ChannelWatchState?>()
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = { testScheduler.currentTime },
+                    onExpired = {},
+                    save = { persisted += it },
+                )
+            watch.start(7, 1_000)
+            watch.start(8, 5_000)
+            advanceTimeBy(1_000)
+            runCurrent()
+            assertTrue(watch.isActive(8))
+            assertEquals(8L, persisted.last()?.bufferId)
+        }
+}

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/MotdNotificationsAlertingTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/MotdNotificationsAlertingTest.kt
@@ -12,9 +12,11 @@ import io.github.trevarj.motd.data.db.MotdDatabase
 import io.github.trevarj.motd.data.db.NetworkEntity
 import io.github.trevarj.motd.data.db.NetworkRole
 import io.github.trevarj.motd.data.prefs.DataStoreSettingsRepository
+import io.github.trevarj.motd.data.sync.BufferStore
 import io.github.trevarj.motd.data.sync.EventProcessor
 import io.github.trevarj.motd.data.sync.MessageNotifier
 import io.github.trevarj.motd.data.sync.TypingTrackerImpl
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.di.ForegroundBufferTrackerImpl
 import io.github.trevarj.motd.irc.event.IrcEvent
 import io.github.trevarj.motd.irc.event.MessageContext
@@ -126,6 +128,195 @@ class MotdNotificationsAlertingTest {
         assertEquals(NotificationCompat.GROUP_ALERT_ALL, notification.groupAlertBehavior)
     }
 
+    private suspend fun mutedChannel(name: String = "#chan"): Long =
+        db.bufferDao().insert(
+            BufferEntity(
+                networkId = networkId,
+                name = name,
+                displayName = name,
+                type = BufferType.CHANNEL,
+                muted = true,
+            ),
+        )
+
+    private val interruptedNotifier =
+        object : MessageNotifier {
+            override suspend fun onIncoming(
+                networkId: Long,
+                bufferId: Long,
+                type: BufferType,
+                hasMention: Boolean,
+                message: IrcEvent.ChatMessage,
+            ) {
+                error("simulated interrupted presentation")
+            }
+        }
+
+    @Test
+    fun pushFirstWatchedMention_onMutedChannel_alertsOnlyOnce() =
+        runTest {
+            val channelId = mutedChannel()
+            val watch = ChannelWatchImpl(backgroundScope, AppClock { 0L }, onExpired = {})
+            watch.start(channelId, null)
+            val processor = EventProcessor(db, TypingTrackerImpl(), notifications, channelWatch = watch)
+            processor.onRegistered(networkId, "me", emptyMap())
+            val message = chat("alert-peer", "me: watched ping", msgid = "watched-push").copy(target = "#chan")
+
+            processor.processPush(networkId, message)
+
+            val posted = postedNotifications().single().notification
+            assertEquals(MotdNotifications.CHANNEL_MENTIONS, posted.channelId)
+            assertAlerting(posted)
+            val style = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(posted)
+            assertEquals(listOf(message.text), style?.messages?.map { it.text.toString() })
+
+            // A dismissed push must not reappear when its live duplicate arrives.
+            context.getSystemService(android.app.NotificationManager::class.java).cancelAll()
+            processor.process(networkId, message)
+            assertEquals(0, postedNotifications().size)
+        }
+
+    @Test
+    fun interruptedWatchedMessages_afterWatchEnds_restoreHistoryAndRecoverSilentlyOnce() =
+        runTest {
+            val channelId = mutedChannel()
+            val watch = ChannelWatchImpl(backgroundScope, AppClock { 0L }, onExpired = {})
+            watch.start(channelId, null)
+            val live = EventProcessor(db, TypingTrackerImpl(), notifications, channelWatch = watch)
+            live.onRegistered(networkId, "me", emptyMap())
+            live.process(
+                networkId,
+                chat("alert-peer", "already presented", "watch-first").copy(target = "#chan"),
+            )
+            assertAlerting(postedNotifications().single().notification)
+
+            val interrupted = EventProcessor(db, TypingTrackerImpl(), interruptedNotifier, channelWatch = watch)
+            interrupted.onRegistered(networkId, "me", emptyMap())
+            interrupted.process(
+                networkId,
+                chat("alert-peer", "ordinary interrupted", "watch-ordinary", 2_000).copy(target = "#chan"),
+            )
+            interrupted.process(
+                networkId,
+                chat("alert-peer", "waves", "watch-action", 3_000).copy(target = "#chan", kind = IrcEvent.ChatKind.ACTION),
+            )
+            interrupted.processPush(
+                networkId,
+                chat("alert-peer", "me: interrupted mention", "watch-mention", 4_000).copy(target = "#chan"),
+            )
+            watch.stop()
+            notifications = MotdNotifications(context, db, ForegroundBufferTrackerImpl(), repo)
+
+            notifications.recoverCanonicalNotifications()
+
+            val recovered = postedNotifications().single().notification
+            assertSilent(recovered)
+            val style = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(recovered)
+            assertEquals(
+                listOf("already presented", "ordinary interrupted", "waves", "me: interrupted mention").sorted(),
+                style?.messages?.map { it.text.toString() }?.sorted(),
+            )
+            context.getSystemService(android.app.NotificationManager::class.java).cancelAll()
+            notifications.recoverCanonicalNotifications()
+            live.process(
+                networkId,
+                chat("alert-peer", "me: interrupted mention", "watch-mention", 4_000).copy(target = "#chan"),
+            )
+            assertEquals(0, postedNotifications().size)
+        }
+
+    @Test
+    fun watchedRecovery_survivesHistoryIdentityUpgradeAndRoomCoalescence() =
+        runTest {
+            val winnerId = mutedChannel("#renamed")
+            val channelId = mutedChannel()
+            val watch = ChannelWatchImpl(backgroundScope, AppClock { 0L }, onExpired = {})
+            val processor = EventProcessor(db, TypingTrackerImpl(), interruptedNotifier, channelWatch = watch)
+            processor.onRegistered(networkId, "me", emptyMap())
+            val message = chat("alert-peer", "survives coalescence").copy(target = "#chan")
+            processor.process(
+                networkId,
+                IrcEvent.HistoryBatch("#renamed", listOf(message.copy(target = "#renamed"))),
+            )
+            watch.start(channelId, null)
+            processor.process(networkId, message)
+            watch.stop()
+            processor.process(
+                networkId,
+                IrcEvent.HistoryBatch(
+                    "#chan",
+                    listOf(message.copy(ctx = message.ctx.copy(msgid = "upgraded-watch"))),
+                ),
+            )
+            BufferStore(db).mergeRooms(winnerId, channelId)
+
+            notifications.recoverCanonicalNotifications()
+
+            assertEquals(1, db.messageDao().countForBuffer(winnerId))
+            val recovered = postedNotifications().single().notification
+            assertSilent(recovered)
+            val style = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(recovered)
+            assertEquals(listOf(message.text), style?.messages?.map { it.text.toString() })
+            context.getSystemService(android.app.NotificationManager::class.java).cancelAll()
+            notifications.recoverCanonicalNotifications()
+            assertEquals(0, postedNotifications().size)
+        }
+
+    @Test
+    fun currentWatch_doesNotMakeEarlierMessagesOrPlaybackRecoverable() =
+        runTest {
+            val channelId = mutedChannel()
+            val watch = ChannelWatchImpl(backgroundScope, AppClock { 0L }, onExpired = {})
+            val processor = EventProcessor(db, TypingTrackerImpl(), interruptedNotifier, channelWatch = watch)
+            processor.onRegistered(networkId, "me", emptyMap())
+            processor.process(
+                networkId,
+                chat("alert-peer", "before watch", "unwatched-live").copy(target = "#chan"),
+            )
+            processor.processPush(
+                networkId,
+                chat("alert-peer", "me: before watch", "unwatched-mention").copy(target = "#chan"),
+            )
+            watch.start(channelId, null)
+            processor.processPush(
+                networkId,
+                chat("alert-peer", "pushed ordinary", "watched-push-ordinary").copy(target = "#chan"),
+            )
+            processor.process(
+                networkId,
+                IrcEvent.HistoryBatch(
+                    "#chan",
+                    listOf(chat("alert-peer", "historical", "watched-history").copy(target = "#chan")),
+                ),
+            )
+            processor.process(
+                networkId,
+                IrcEvent.PlaybackBatch(
+                    source = IrcEvent.PlaybackSource.ZNC_PLAYBACK,
+                    target = "#chan",
+                    items =
+                        listOf(
+                            IrcEvent.PlaybackItem.from(
+                                chat("alert-peer", "replayed", "watched-replay").copy(target = "#chan"),
+                                ordinal = 0,
+                            ),
+                        ),
+                ),
+            )
+            processor.process(
+                networkId,
+                chat("alert-peer", "notice", "watched-notice").copy(target = "#chan", kind = IrcEvent.ChatKind.NOTICE),
+            )
+            processor.process(
+                networkId,
+                chat("me", "me: self", "watched-self").copy(target = "#chan", isSelf = true),
+            )
+
+            notifications.recoverCanonicalNotifications()
+
+            assertEquals(0, postedNotifications().size)
+        }
+
     @Test
     fun firstPresentation_ofDm_alertsThroughMessagesChannel() =
         runTest {
@@ -176,19 +367,7 @@ class MotdNotificationsAlertingTest {
     @Test
     fun recoveryRepost_staysSilent() =
         runTest {
-            val failing =
-                object : MessageNotifier {
-                    override suspend fun onIncoming(
-                        networkId: Long,
-                        bufferId: Long,
-                        type: BufferType,
-                        hasMention: Boolean,
-                        message: IrcEvent.ChatMessage,
-                    ) {
-                        error("simulated interrupted presentation")
-                    }
-                }
-            val processor = EventProcessor(db, TypingTrackerImpl(), failing)
+            val processor = EventProcessor(db, TypingTrackerImpl(), interruptedNotifier)
             processor.onRegistered(networkId, "me", emptyMap())
             processor.process(networkId, chat("alert-peer", "recover me", msgid = "recover-alert"))
             assertEquals(0, postedNotifications().size)

--- a/app/src/test/kotlin/io/github/trevarj/motd/service/NotificationDecisionTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/service/NotificationDecisionTest.kt
@@ -63,6 +63,60 @@ class NotificationDecisionTest {
     }
 
     @Test
+    fun `watched posts despite mute`() {
+        assertTrue(
+            shouldPostNotification(
+                foreground = false,
+                muted = true,
+                senderIsFriend = false,
+                senderIsFool = false,
+                watched = true,
+            ),
+        )
+        assertTrue(
+            shouldPostNotification(
+                foreground = false,
+                muted = false,
+                senderIsFriend = false,
+                senderIsFool = false,
+                watched = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `watched still respects foreground, fool and already read`() {
+        assertFalse(
+            shouldPostNotification(
+                foreground = true,
+                muted = true,
+                senderIsFriend = false,
+                senderIsFool = false,
+                watched = true,
+            ),
+        )
+        assertFalse(
+            shouldPostNotification(
+                foreground = false,
+                muted = true,
+                senderIsFriend = false,
+                senderIsFool = true,
+                watched = true,
+            ),
+        )
+        assertFalse(
+            shouldPostNotification(
+                foreground = false,
+                muted = true,
+                senderIsFriend = false,
+                senderIsFool = false,
+                alreadyRead = true,
+                watched = true,
+            ),
+        )
+    }
+
+    @Test
     fun `read marker dismisses only when it covers the newest notification`() {
         val latest =
             io.github.trevarj.motd.data.db

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoTopicMutationTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoTopicMutationTest.kt
@@ -19,9 +19,13 @@ import io.github.trevarj.motd.data.prefs.Settings
 import io.github.trevarj.motd.data.prefs.SettingsRepository
 import io.github.trevarj.motd.data.prefs.ThemeMode
 import io.github.trevarj.motd.data.repo.BufferRepository
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.irc.client.IrcClient
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.service.CertPrompt
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchDuration
+import io.github.trevarj.motd.service.ChannelWatchImpl
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.DeliveryMode
 import io.github.trevarj.motd.service.SendAcceptance
@@ -35,6 +39,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -46,6 +51,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -227,6 +233,40 @@ class ChannelInfoTopicMutationTest {
             collector.cancelAndJoin()
         }
 
+    @Test
+    fun `stale redirect route watches the canonical channel and reports its notify level`() =
+        runTest {
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = {},
+                )
+            val canonical = BufferEntity(BUFFER_ID, 1, "#room", "#room", BufferType.CHANNEL, muted = true)
+            val viewModel =
+                viewModel(
+                    manager = FakeConnectionManager(),
+                    buffers = FakeBufferRepository(canonical),
+                    channelWatch = watch,
+                )
+            viewModel.init(42)
+            viewModel.state.first { it.buffer != null }
+            backgroundScope.launch { viewModel.notifyLevel.collect() }
+            runCurrent()
+
+            viewModel.startWatch(ChannelWatchDuration.FOREVER).join()
+            runCurrent()
+
+            assertTrue(watch.isActive(canonical.id))
+            assertEquals(ChannelNotifyLevel.All(minutesLeft = null, overridesMute = true), viewModel.notifyLevel.value)
+
+            viewModel.stopWatch().join()
+            runCurrent()
+
+            assertFalse(watch.isActive(canonical.id))
+            assertEquals(ChannelNotifyLevel.Muted, viewModel.notifyLevel.value)
+        }
+
     private suspend fun TestScope.assertRejectedLeaveDoesNotNavigate(manager: FakeConnectionManager) {
         val viewModel = viewModel(manager)
         viewModel.init(BUFFER_ID)
@@ -243,23 +283,26 @@ class ChannelInfoTopicMutationTest {
         collector.cancelAndJoin()
     }
 
-    private fun viewModel(manager: ConnectionManager) =
-        ChannelInfoViewModel(
-            bufferRepository = FakeBufferRepository(),
-            connectionManager = manager,
-            draftStore = ComposerDraftStore(database),
-            settingsRepository = FakeSettingsRepository(),
-            userDao = database.userDao(),
-            networkIdentityDao = database.networkIdentityDao(),
-        )
+    private fun viewModel(
+        manager: ConnectionManager,
+        buffers: BufferRepository = FakeBufferRepository(),
+        channelWatch: ChannelWatch = ChannelWatch.Noop,
+    ) = ChannelInfoViewModel(
+        bufferRepository = buffers,
+        connectionManager = manager,
+        draftStore = ComposerDraftStore(database),
+        settingsRepository = FakeSettingsRepository(),
+        userDao = database.userDao(),
+        networkIdentityDao = database.networkIdentityDao(),
+        channelWatch = channelWatch,
+    )
 
-    private class FakeBufferRepository : BufferRepository {
+    private class FakeBufferRepository(
+        private val buffer: BufferEntity = BufferEntity(BUFFER_ID, 1, "#room", "#room", BufferType.CHANNEL),
+    ) : BufferRepository {
         override fun observeChatList(): Flow<List<ChatListRow>> = flowOf(emptyList())
 
-        override fun observeBuffer(id: Long): Flow<BufferEntity?> =
-            flowOf(
-                BufferEntity(BUFFER_ID, 1, "#room", "#room", BufferType.CHANNEL),
-            )
+        override fun observeBuffer(id: Long): Flow<BufferEntity?> = flowOf(buffer)
 
         override fun observeMembers(bufferId: Long): Flow<List<MemberEntity>> = flowOf(emptyList())
 

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelNotifyLevelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelNotifyLevelTest.kt
@@ -38,6 +38,19 @@ class ChannelNotifyLevelTest {
     }
 
     @Test
+    fun `a forever watch reports no remaining minutes`() {
+        val watch = ChannelWatchState(bufferId = 7, expiresAt = Long.MAX_VALUE)
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = null, overridesMute = false),
+            deriveNotifyLevel(muted = false, watch = watch, bufferId = 7, nowMillis = 0),
+        )
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = null, overridesMute = true),
+            deriveNotifyLevel(muted = true, watch = watch, bufferId = 7, nowMillis = 5_000_000),
+        )
+    }
+
+    @Test
     fun `remaining minutes round up and never reach zero`() {
         val watch = ChannelWatchState(bufferId = 7, expiresAt = 90_000)
         assertEquals(

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelNotifyLevelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelNotifyLevelTest.kt
@@ -1,0 +1,52 @@
+package io.github.trevarj.motd.ui.channelinfo
+
+import io.github.trevarj.motd.service.ChannelWatchState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Precedence for the channel-info notifications row: live watch > mute > mentions-only. */
+class ChannelNotifyLevelTest {
+    @Test
+    fun `no watch reports mute or mentions only`() {
+        assertEquals(ChannelNotifyLevel.MentionsOnly, deriveNotifyLevel(muted = false, watch = null, bufferId = 7, nowMillis = 0))
+        assertEquals(ChannelNotifyLevel.Muted, deriveNotifyLevel(muted = true, watch = null, bufferId = 7, nowMillis = 0))
+    }
+
+    @Test
+    fun `a watch on another buffer does not apply`() {
+        val watch = ChannelWatchState(bufferId = 9, expiresAt = 600_000)
+        assertEquals(ChannelNotifyLevel.Muted, deriveNotifyLevel(muted = true, watch = watch, bufferId = 7, nowMillis = 0))
+    }
+
+    @Test
+    fun `an expired watch falls back to the buffer state`() {
+        val watch = ChannelWatchState(bufferId = 7, expiresAt = 1_000)
+        assertEquals(ChannelNotifyLevel.MentionsOnly, deriveNotifyLevel(muted = false, watch = watch, bufferId = 7, nowMillis = 1_000))
+    }
+
+    @Test
+    fun `an active watch reports remaining minutes and mute override`() {
+        val watch = ChannelWatchState(bufferId = 7, expiresAt = 900_000)
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = 15, overridesMute = false),
+            deriveNotifyLevel(muted = false, watch = watch, bufferId = 7, nowMillis = 0),
+        )
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = 15, overridesMute = true),
+            deriveNotifyLevel(muted = true, watch = watch, bufferId = 7, nowMillis = 0),
+        )
+    }
+
+    @Test
+    fun `remaining minutes round up and never reach zero`() {
+        val watch = ChannelWatchState(bufferId = 7, expiresAt = 90_000)
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = 2, overridesMute = false),
+            deriveNotifyLevel(muted = false, watch = watch, bufferId = 7, nowMillis = 0),
+        )
+        assertEquals(
+            ChannelNotifyLevel.All(minutesLeft = 1, overridesMute = false),
+            deriveNotifyLevel(muted = false, watch = watch, bufferId = 7, nowMillis = 89_999),
+        )
+    }
+}

--- a/app/src/test/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/ui/chat/ChatViewModelTest.kt
@@ -63,6 +63,7 @@ import io.github.trevarj.motd.data.visibility.MessageVisibilityReader
 import io.github.trevarj.motd.data.visibility.MessageVisibilitySpec
 import io.github.trevarj.motd.data.visibility.messagePagingQuery
 import io.github.trevarj.motd.dcc.DccTransferController
+import io.github.trevarj.motd.di.AppClock
 import io.github.trevarj.motd.irc.client.HistoryAvailability
 import io.github.trevarj.motd.irc.client.HistoryReferenceType
 import io.github.trevarj.motd.irc.client.IrcClient
@@ -73,6 +74,9 @@ import io.github.trevarj.motd.irc.proto.IrcMessage
 import io.github.trevarj.motd.irc.transport.IrcTransport
 import io.github.trevarj.motd.irc.transport.TransportFactory
 import io.github.trevarj.motd.service.CertPrompt
+import io.github.trevarj.motd.service.ChannelWatch
+import io.github.trevarj.motd.service.ChannelWatchDuration
+import io.github.trevarj.motd.service.ChannelWatchImpl
 import io.github.trevarj.motd.service.ConnectionManager
 import io.github.trevarj.motd.service.DeliveryMode
 import io.github.trevarj.motd.service.ForegroundBufferTracker
@@ -1430,6 +1434,37 @@ class ChatViewModelTest {
             advanceUntilIdle()
 
             assertEquals(null, foreground.foregroundBufferId.value)
+        }
+
+    @Test
+    fun `stale redirect route starts and stops a canonical channel watch`() =
+        runTest {
+            val canonical = channel.copy(id = 42)
+            val watch =
+                ChannelWatchImpl(
+                    scope = backgroundScope,
+                    clock = AppClock { testScheduler.currentTime },
+                    onExpired = {},
+                )
+            val vm =
+                viewModel(
+                    buffer = canonical,
+                    manager = FakeConnectionManager(network.id),
+                    routeBufferId = channel.id,
+                    channelWatch = watch,
+                )
+            vm.state.first { it.buffer != null }
+
+            vm.startChannelWatch(ChannelWatchDuration.FOREVER)
+            runCurrent()
+
+            assertTrue(watch.isActive(canonical.id))
+            assertEquals(canonical.id, vm.activeWatch.value?.bufferId)
+
+            vm.stopChannelWatch()
+            runCurrent()
+
+            assertNull(vm.activeWatch.value)
         }
 
     @Test
@@ -3538,6 +3573,7 @@ class ChatViewModelTest {
         // Injectable so a test can push prefills at the exact store instance the VM listens to.
         drafts: ComposerDraftStore = ComposerDraftStore(db),
         replyPrefs: ReplyPrefs = FakeReplyPrefs(),
+        channelWatch: ChannelWatch = ChannelWatch.Noop,
     ): ChatViewModel {
         val routeState = mutableMapOf<String, Any>("bufferId" to routeBufferId)
         jumpToMsgid?.let { routeState["jumpToMsgid"] = it }
@@ -3576,6 +3612,7 @@ class ChatViewModelTest {
             audioPlaybackController = FakeAudioPlaybackController(),
             directMediaPolicy = directMediaPolicy,
             gapFiller = gapFiller,
+            channelWatch = channelWatch,
         )
     }
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/AudioPlayerUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/AudioPlayerUiTest.kt
@@ -29,6 +29,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class AudioPlayerUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun uncached_audio_uses_download_action() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatFolderUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatFolderUiTest.kt
@@ -35,6 +35,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatFolderUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatHistoryFooterUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatHistoryFooterUiTest.kt
@@ -34,6 +34,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatHistoryFooterUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatHistorySyncIndicatorUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatHistorySyncIndicatorUiTest.kt
@@ -43,6 +43,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatHistorySyncIndicatorUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListPresenceUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListPresenceUiTest.kt
@@ -27,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatListPresenceUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSelectionUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSelectionUiTest.kt
@@ -45,6 +45,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatListSelectionUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun selected_row_exposes_selected_semantics_on_the_full_row() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSyncHeaderUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSyncHeaderUiTest.kt
@@ -28,6 +28,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatListSyncHeaderUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSyncIndicatorUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListSyncIndicatorUiTest.kt
@@ -26,6 +26,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatListSyncIndicatorUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListTitleConnectivityUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatListTitleConnectivityUiTest.kt
@@ -29,6 +29,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatListTitleConnectivityUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatPlaceholderUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ChatPlaceholderUiTest.kt
@@ -21,6 +21,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChatPlaceholderUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ComposerSendClearUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ComposerSendClearUiTest.kt
@@ -48,6 +48,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ComposerSendClearUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ComposerUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ComposerUiTest.kt
@@ -41,6 +41,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ComposerUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose: ComposeContentTestRule = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/FoolCollapseUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/FoolCollapseUiTest.kt
@@ -25,6 +25,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class FoolCollapseUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun collapse_affordance_fills_its_timeline_width_and_remains_tappable() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/HistoryGapDividerUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/HistoryGapDividerUiTest.kt
@@ -35,6 +35,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class HistoryGapDividerUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/InviteUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/InviteUiTest.kt
@@ -37,6 +37,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class InviteUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/LinkPreviewCardUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/LinkPreviewCardUiTest.kt
@@ -21,6 +21,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class LinkPreviewCardUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun text_preview_exposes_a_dedicated_body() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/MessageTimelineUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/MessageTimelineUiTest.kt
@@ -41,6 +41,9 @@ import kotlin.math.abs
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class MessageTimelineUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/MotionDurationScaleTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/MotionDurationScaleTest.kt
@@ -27,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class MotionDurationScaleTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose: ComposeContentTestRule = createComposeRule(ReducedMotionScale)
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/NetworkGuidanceUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/NetworkGuidanceUiTest.kt
@@ -35,6 +35,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class NetworkGuidanceUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     private val openedUrls = mutableListOf<String>()

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/OnboardingBouncerUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/OnboardingBouncerUiTest.kt
@@ -38,6 +38,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class OnboardingBouncerUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ReplyPreviewUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ReplyPreviewUiTest.kt
@@ -21,6 +21,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ReplyPreviewUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ScrollToBottomFabUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ScrollToBottomFabUiTest.kt
@@ -19,6 +19,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ScrollToBottomFabUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun physicalTapDispatchesTheFabClick() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ServerDrawerUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ServerDrawerUiTest.kt
@@ -26,6 +26,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ServerDrawerUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ThemeStateRetentionUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ThemeStateRetentionUiTest.kt
@@ -27,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ThemeStateRetentionUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/UiDispatcherResetRule.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/UiDispatcherResetRule.kt
@@ -1,0 +1,41 @@
+package io.github.trevarj.motd
+
+import androidx.compose.ui.platform.AndroidUiDispatcher
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import kotlin.coroutines.ContinuationInterceptor
+
+/**
+ * Paging publishes rows via the JVM-wide [AndroidUiDispatcher.Main]; a Robolectric looper reset can
+ * strand its scheduled flags so nothing posts again. Clear that state around each test.
+ */
+class UiDispatcherResetRule : TestRule {
+    override fun apply(
+        base: Statement,
+        description: Description,
+    ): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                reset()
+                try {
+                    base.evaluate()
+                } finally {
+                    // A test can wedge the dispatcher at disposal; leave it clean for the next class.
+                    reset()
+                }
+            }
+        }
+
+    private fun reset() {
+        val dispatcher = AndroidUiDispatcher.Main[ContinuationInterceptor] ?: return
+        val type = dispatcher.javaClass
+
+        fun field(name: String) = type.getDeclaredField(name).also { it.isAccessible = true }
+        synchronized(field("lock").get(dispatcher)) {
+            (field("toRunTrampolined").get(dispatcher) as ArrayDeque<*>).clear()
+            field("scheduledTrampolineDispatch").setBoolean(dispatcher, false)
+            field("scheduledFrameDispatch").setBoolean(dispatcher, false)
+        }
+    }
+}

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/VoiceRecordingPanelUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/VoiceRecordingPanelUiTest.kt
@@ -27,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class VoiceRecordingPanelUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun locking_keeps_the_recording_panel_height_stable() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/agentwire/AgentwireLiveSessionsUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/agentwire/AgentwireLiveSessionsUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -24,6 +25,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class AgentwireLiveSessionsUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/agentwire/AgentwireSyncFailureUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/agentwire/AgentwireSyncFailureUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -25,6 +26,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class AgentwireSyncFailureUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/gesture/GestureOrbUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/gesture/GestureOrbUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.up
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.gesture.radial.GESTURE_MENU_A11Y_DIALOG_TAG
 import io.github.trevarj.motd.gesture.radial.GESTURE_MENU_SCRIM_TAG
 import io.github.trevarj.motd.gesture.radial.GESTURE_ORB_TAG
@@ -34,6 +35,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class GestureOrbUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelControlsUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelControlsUiTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferEntity
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MemberEntity
@@ -32,6 +33,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChannelControlsUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     private val members = listOf(MemberEntity(1, "me", "@"), MemberEntity(1, "bob", ""))

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelControlsUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelControlsUiTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -16,6 +17,8 @@ import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferEntity
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MemberEntity
+import io.github.trevarj.motd.service.ChannelWatchDuration
+import io.github.trevarj.motd.ui.components.ChannelWatchDialog
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -111,8 +114,34 @@ class ChannelControlsUiTest {
     }
 
     @Test
-    fun limitDialog_presetsIncludeCommonRoomSizes() {
-        assertEquals(listOf(25, 50, 100, 500), LIMIT_PRESETS)
+    @Config(qualifiers = "w640dp-h360dp-land")
+    fun watchActionsRemainReachableInShortWindows() {
+        var selected: ChannelWatchDuration? = null
+        var stopped = 0
+        compose.setContent {
+            MotdTheme {
+                ChannelWatchDialog(
+                    watchActive = true,
+                    onStart = { selected = it },
+                    onStop = { stopped++ },
+                    onDismiss = {},
+                    tagPrefix = "channelinfo",
+                )
+            }
+        }
+
+        compose
+            .onNodeWithTag("channelinfo_watch_forever")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+        compose.runOnIdle { assertEquals(ChannelWatchDuration.FOREVER, selected) }
+        compose
+            .onNodeWithTag("channelinfo_watch_stop")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+        compose.runOnIdle { assertEquals(1, stopped) }
     }
 
     @Composable

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoTopicEditUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channelinfo/ChannelInfoTopicEditUiTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferEntity
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.ui.theme.MotdTheme
@@ -32,6 +33,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChannelInfoTopicEditUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channellist/ChannelListScreenUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/channellist/ChannelListScreenUiTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.irc.client.ChannelListing
 import io.github.trevarj.motd.irc.event.IrcClientState
 import io.github.trevarj.motd.ui.theme.MotdTheme
@@ -26,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ChannelListScreenUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/AttachmentConfirmationSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/AttachmentConfirmationSheetUiTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.core.app.ApplicationProvider
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.attachment.AttachmentSource
 import io.github.trevarj.motd.attachment.PasteBackendConfig
 import io.github.trevarj.motd.ui.theme.MotdTheme
@@ -21,6 +22,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class AttachmentConfirmationSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/InviteUserSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/InviteUserSheetUiTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.JoinedChannelRow
 import io.github.trevarj.motd.irc.proto.IrcIdentityRules
 import io.github.trevarj.motd.service.PresenceKey
@@ -25,6 +26,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class InviteUserSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     private val current = JoinedChannelRow(1, 7, "#current", null)

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/MessageActionSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/MessageActionSheetUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.components.ReactionChip
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertTrue
@@ -22,6 +23,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class MessageActionSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/NickSheetKickUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/NickSheetKickUiTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.components.ReasonPresetChips
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
@@ -18,6 +19,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class NickSheetKickUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/PhotoPickerSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/PhotoPickerSheetUiTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -18,6 +19,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class PhotoPickerSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/RemoteMediaTimelineTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chat/RemoteMediaTimelineTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.audio.AudioMetadata
 import io.github.trevarj.motd.data.db.MessageEntity
 import io.github.trevarj.motd.data.db.MessageKind
@@ -28,6 +29,9 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class RemoteMediaTimelineTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScrollPlacementTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/ChatListScrollPlacementTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.IntOffset
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.ComposeFoundationWorkarounds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -50,6 +51,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class ChatListScrollPlacementTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/FolderManagementTopBarUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/FolderManagementTopBarUiTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -15,6 +16,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class FolderManagementTopBarUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/GlobalFeedEntryPointsTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/GlobalFeedEntryPointsTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.ChatListRow
 import io.github.trevarj.motd.data.db.NetworkEntity
@@ -26,6 +27,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class GlobalFeedEntryPointsTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun drawerRow_hidesByDefaultAndAppearsWithTheLab() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/NewConversationSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/chatlist/NewConversationSheetUiTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.AnnotatedString
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.NetworkEntity
 import io.github.trevarj.motd.data.db.NetworkRole
 import io.github.trevarj.motd.ui.theme.MotdTheme
@@ -39,6 +40,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class NewConversationSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/AvatarEditorSheetUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/AvatarEditorSheetUiTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -19,6 +20,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class AvatarEditorSheetUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/ComposerEditorStateTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/ComposerEditorStateTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.irc.format.IRC_BOLD
 import io.github.trevarj.motd.irc.format.IRC_COLOR
 import io.github.trevarj.motd.irc.format.IRC_RESET
@@ -40,6 +41,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class ComposerEditorStateTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/EmptyStateLayoutTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/EmptyStateLayoutTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -33,6 +34,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class EmptyStateLayoutTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/InlineMediaPreviewTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/components/InlineMediaPreviewTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -26,6 +27,9 @@ import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class InlineMediaPreviewTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/feed/GlobalFeedScreenTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/feed/GlobalFeedScreenTest.kt
@@ -21,6 +21,7 @@ import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import androidx.paging.compose.collectAsLazyPagingItems
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MessageEntity
 import io.github.trevarj.motd.data.db.MessageKind
@@ -46,6 +47,9 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class GlobalFeedScreenTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/imageviewer/ImageViewerGestureUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/imageviewer/ImageViewerGestureUiTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import kotlinx.coroutines.CompletableDeferred
 import me.saket.telephoto.zoomable.ZoomSpec
@@ -35,6 +36,9 @@ private const val IMAGE_LOAD_WAIT_MS = 5_000L
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class ImageViewerGestureUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     /** Coil decodes an in-memory bitmap without touching the network, so no fixture server. */

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/search/SearchScreenUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/search/SearchScreenUiTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.BufferType
 import io.github.trevarj.motd.data.db.MessageEntity
 import io.github.trevarj.motd.data.db.MessageKind
@@ -27,6 +28,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class SearchScreenUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/AppearanceFolderLayoutUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/AppearanceFolderLayoutUiTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.prefs.AppearanceConfig
 import io.github.trevarj.motd.data.prefs.FolderDisplayMode
 import io.github.trevarj.motd.data.prefs.Settings
@@ -20,6 +21,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class AppearanceFolderLayoutUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/BackupRestoreControlsUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/BackupRestoreControlsUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.backup.BackupImportMode
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
@@ -24,6 +25,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class BackupRestoreControlsUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun passwordField_exposesVisibilityToggle() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/BackupRestoreFlowUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/BackupRestoreFlowUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.backup.BackupExportMode
 import io.github.trevarj.motd.data.backup.BackupImportMode
 import io.github.trevarj.motd.data.backup.ConfigurationImportPreview
@@ -28,6 +29,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class BackupRestoreFlowUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/ChatSettingsComposerToolsTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/ChatSettingsComposerToolsTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.audio.VoiceConfig
 import io.github.trevarj.motd.avatar.AvatarConfig
 import io.github.trevarj.motd.data.prefs.ContentPreviewConfig
@@ -23,6 +24,9 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ChatSettingsComposerToolsTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule
     val compose = createComposeRule()
 

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/DeliverySettingsNotificationPermissionUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/DeliverySettingsNotificationPermissionUiTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.service.DeliveryMode
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Rule
@@ -19,6 +20,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class DeliverySettingsNotificationPermissionUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test fun persistent_socket_shows_notification_remediation_without_push_status() {

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/NetworkToolsOperatorUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/NetworkToolsOperatorUiTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.irc.proto.IrcMessage
 import io.github.trevarj.motd.ui.theme.MotdTheme
 import org.junit.Assert.assertEquals
@@ -23,6 +24,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class NetworkToolsOperatorUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/SettingsHomeAndPrimitivesUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/SettingsHomeAndPrimitivesUiTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.data.db.NetworkEntity
 import io.github.trevarj.motd.data.db.NetworkRole
 import io.github.trevarj.motd.ui.nav.SettingsTarget
@@ -36,6 +37,9 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class SettingsHomeAndPrimitivesUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test

--- a/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/SettingsOuterShellUiTest.kt
+++ b/app/src/testDebug/kotlin/io/github/trevarj/motd/ui/settings/SettingsOuterShellUiTest.kt
@@ -3,6 +3,7 @@ package io.github.trevarj.motd.ui.settings
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import io.github.trevarj.motd.UiDispatcherResetRule
 import io.github.trevarj.motd.ui.settings.addnetwork.AddNetworkContent
 import io.github.trevarj.motd.ui.settings.addnetwork.AddNetworkUiState
 import io.github.trevarj.motd.ui.settings.bouncer.BouncerControlCallbacks
@@ -24,6 +25,9 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = "w411dp-h891dp")
 class SettingsOuterShellUiTest {
+    @get:Rule(order = 1)
+    val uiDispatcher = UiDispatcherResetRule()
+
     @get:Rule val compose = createComposeRule()
 
     @Test


### PR DESCRIPTION
Temporary "notify on every message" for one channel, 15/30/60 min.

## Reasoning

I was bored waiting for someone the other day. I like reading longform on the phone. But I also like chatting on motd sometimes in such a scenario. I do *not* like to switch between what I am reading and the app to see if anything happened.

The solution is to enable a "notify on any movement" action that you can trigger on a channel for X miunutes, which this PR adds.

It ignores your own nick, of course, should you use other clients at the same time.

I placed it on channel details, as Mute is there as well. This feature will override mute. The reasoning being that if you are *extra* bored, you might want to turn some channel you don't care about on a 15 minute high alert as well!

I also put it under the overflow thre dots menu, but I'm not sure, that puts it on two places, but you can see what you prefer. Personally I think maybe the mute placement is enough.

## Screenshot

<img width="960" height="2142" alt="Screenshot_20260905-151810" src="https://github.com/user-attachments/assets/45b4bc5e-f366-4ae7-8e42-0a45b572e32b" />
<img width="960" height="2142" alt="Screenshot_20260905-151807" src="https://github.com/user-attachments/assets/d3596bc2-3108-4c6c-b159-6ddaf58e6c27" />


## Clanker Notes

- Start from the chat overflow menu or the new **Notifications** row in channel info. One channel at a time; starting another replaces it.
- Applies to live socket PRIVMSG and ACTION only. NOTICE, history, and replay are unchanged.
- A watch overrides buffer mute. Foreground, fools, and already-read suppression still apply.
- Channel info row shows the level: Mentions only / Muted / All messages, N min left (overrides mute). Ticks every 30 s while active.
- Persisted in a `channel_watch` DataStore and re-armed after process death; stale watches expire on restore.
- Single "Watch ended" notification at expiry on the messages channel, id `0x30000001`, excluded from legacy retirement.
- `MessageNotifier.onCanonicalIncoming` and `shouldPostNotification` gain a `watched` flag; `ChannelWatchDuration` enum replaces loose constants.
- Test tags: `chat_watch_15|30|60|stop`, `channelinfo_notify_level`, `channelinfo_notify_dialog`, `channelinfo_watch_15|30|60|stop`.
- Verified: ktlint, notify/watch/processor/channel-info unit tests, assembleDebug, debug install on Pixel 9 Pro. No required E2E journey touches these tags.
