### PR TITLE
fix(notifications): bound the startup recovery scans

### DIFF
--- a/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/data/db/Daos.kt
@@ -2473,17 +2473,36 @@ interface CanonicalTimelineDao {
     )
     suspend fun releaseNotification(eventId: TimelineEventId)
 
+    // Both recovery scans are floored at the later of `newest event - :window` and the serverTime
+    // of the :maxRows-th newest event (so at most :maxRows rows plus ties), walking a bounded index range instead of the whole
+    // table: `notificationHandled` only ever flips to 1 one row at a time, so on a large archive
+    // nearly every row matches the flag predicates and an unbounded scan costs seconds at every
+    // process start. The row cap keeps a flooding channel from making the time window unbounded;
+    // anchoring on stored serverTimes rather than the wall clock keeps the floor meaningful when the
+    // device clock or the server's timestamps are off.
     @Query(
         """UPDATE messages SET notificationClaimed = 0, notificationClaimOwner = NULL
-           WHERE notificationHandled = 0 AND notificationClaimed = 1
+           WHERE serverTime >= MAX(
+                     (SELECT MAX(serverTime) FROM messages) - :window,
+                     COALESCE((SELECT serverTime FROM messages
+                               ORDER BY serverTime DESC LIMIT 1 OFFSET :maxRows - 1), 0))
+             AND notificationHandled = 0 AND notificationClaimed = 1
              AND (notificationClaimOwner IS NULL OR notificationClaimOwner != :currentOwner)""",
     )
-    suspend fun releaseInterruptedNotificationClaims(currentOwner: String)
+    suspend fun releaseInterruptedNotificationClaims(
+        currentOwner: String,
+        window: Long,
+        maxRows: Int,
+    )
 
     @Query(
         """SELECT m.* FROM messages m
            JOIN buffers b ON b.id = m.bufferId
-           WHERE m.notificationHandled = 0 AND m.notificationClaimed = 0
+           WHERE m.serverTime >= MAX(
+                     (SELECT MAX(serverTime) FROM messages) - :window,
+                     COALESCE((SELECT serverTime FROM messages
+                               ORDER BY serverTime DESC LIMIT 1 OFFSET :maxRows - 1), 0))
+             AND m.notificationHandled = 0 AND m.notificationClaimed = 0
              AND m.isSelf = 0 AND m.failed = 0
              AND EXISTS (
                  SELECT 1 FROM event_observations o
@@ -2500,7 +2519,11 @@ interface CanonicalTimelineDao {
            ORDER BY m.serverTime, m.timelineOrder, m.id
            LIMIT :limit""",
     )
-    suspend fun pendingNotifications(limit: Int): List<TimelineEventEntity>
+    suspend fun pendingNotifications(
+        limit: Int,
+        window: Long,
+        maxRows: Int,
+    ): List<TimelineEventEntity>
 }
 
 @Dao

--- a/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
+++ b/app/src/main/kotlin/io/github/trevarj/motd/service/MotdNotifications.kt
@@ -149,8 +149,8 @@ class MotdNotifications
         /** Rebuild interrupted chat/invitation presentation directly from canonical database state. */
         internal suspend fun recoverCanonicalNotifications() {
             val dao = db.canonicalTimelineDao()
-            dao.releaseInterruptedNotificationClaims(NotificationClaimSession.owner)
-            for (event in dao.pendingNotifications(MAX_RECOVERY_NOTIFICATIONS)) {
+            dao.releaseInterruptedNotificationClaims(NotificationClaimSession.owner, RECOVERY_WINDOW_MS, RECOVERY_SCAN_ROWS)
+            for (event in dao.pendingNotifications(MAX_RECOVERY_NOTIFICATIONS, RECOVERY_WINDOW_MS, RECOVERY_SCAN_ROWS)) {
                 if (dao.claimNotification(event.id, NotificationClaimSession.owner) != 1) continue
                 try {
                     val buffer = db.bufferDao().observeById(event.bufferId)
@@ -904,6 +904,12 @@ class MotdNotifications
                 )
             private const val V10_NOTIFICATION_RESET = "v10_notification_reset"
             private const val MAX_RECOVERY_NOTIFICATIONS = 200
+
+            /** Recovery only re-presents events this close to the newest stored one; older ones are stale. */
+            private const val RECOVERY_WINDOW_MS = 48L * 60 * 60 * 1000
+
+            /** ...and never looks past this many of the newest events, however busy the last 48h were. */
+            private const val RECOVERY_SCAN_ROWS = 5_000
 
             // Deep-link extras carried by a message notification's content intent (tap → open + jump).
             const val ACTION_OPEN_BUFFER = "io.github.trevarj.motd.OPEN_BUFFER"

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/db/AllMigrationsTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/db/AllMigrationsTest.kt
@@ -492,7 +492,7 @@ class AllMigrationsTest {
                 )
                 assertEquals(
                     listOf("me: mention"),
-                    migrated.canonicalTimelineDao().pendingNotifications(10).map { it.text },
+                    migrated.canonicalTimelineDao().pendingNotifications(10, window = Long.MAX_VALUE / 2, maxRows = Int.MAX_VALUE).map { it.text },
                 )
                 assertEquals(
                     listOf("me: mention"),

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/db/NotificationRecoveryDaoTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/db/NotificationRecoveryDaoTest.kt
@@ -1,0 +1,92 @@
+package io.github.trevarj.motd.data.db
+
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Startup notification recovery must stay bounded by the recovery window measured from the newest
+ * stored event, so a large archive never turns process start into a full `messages` scan.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NotificationRecoveryDaoTest {
+    private lateinit var db: MotdDatabase
+    private var networkId: Long = 0
+    private var bufferId: Long = 0
+
+    @Before
+    fun setUp() =
+        runTest {
+            db = inMemoryDb()
+            networkId = db.networkDao().insert(network())
+            bufferId = db.bufferDao().insert(buffer(networkId, "#chan"))
+        }
+
+    @After
+    fun tearDown() = db.close()
+
+    private suspend fun liveMention(
+        serverTime: Long,
+        text: String,
+    ): TimelineEventId {
+        val dao = db.canonicalTimelineDao()
+        val id = dao.insertEvent(message(bufferId, text, serverTime = serverTime, dedupKey = text, hasMention = true))
+        dao.insertObservation(
+            EventObservationEntity(
+                networkId = networkId,
+                timelineEventId = id,
+                origin = ObservationOrigin.LIVE,
+                connectionGeneration = null,
+                receiveOrder = id,
+                batchId = null,
+                timeProvenance = TimeProvenance.SERVER_TAG,
+                semanticFingerprint = text.toByteArray(),
+                batchExactOrdinal = null,
+                observedAt = serverTime,
+            ),
+        )
+        return id
+    }
+
+    @Test
+    fun recoveryOnlyConsidersEventsWithinTheWindowOfTheNewestOne() =
+        runTest {
+            val dao = db.canonicalTimelineDao()
+            val stale = liveMention(1_000, "stale")
+            val recent = liveMention(1_000_000, "recent")
+            assertEquals(1, dao.claimNotification(stale, "dead-process"))
+            assertEquals(1, dao.claimNotification(recent, "dead-process"))
+
+            dao.releaseInterruptedNotificationClaims("me", window = 10_000, maxRows = Int.MAX_VALUE)
+
+            // Only the claim inside the window is released; the stale one stays claimed and is never
+            // re-presented, and pendingNotifications ignores it even if it were released.
+            assertEquals(listOf(recent), dao.pendingNotifications(10, window = 10_000, maxRows = Int.MAX_VALUE).map { it.id })
+            assertEquals(0, dao.claimNotification(stale, "me"))
+            assertEquals(1, dao.claimNotification(recent, "me"))
+
+            // An unbounded window proves the window, not the claim state, gated the stale row.
+            dao.releaseInterruptedNotificationClaims("me", window = Long.MAX_VALUE / 2, maxRows = Int.MAX_VALUE)
+            assertEquals(1, dao.claimNotification(stale, "me"))
+        }
+
+    @Test
+    fun recoveryNeverLooksPastTheNewestMaxRowsEvenInsideTheTimeWindow() =
+        runTest {
+            val dao = db.canonicalTimelineDao()
+            // Three events one millisecond apart: all inside any sane time window.
+            val oldest = liveMention(1_000, "oldest")
+            val middle = liveMention(1_001, "middle")
+            val newest = liveMention(1_002, "newest")
+            listOf(oldest, middle, newest).forEach { assertEquals(1, dao.claimNotification(it, "dead-process")) }
+
+            dao.releaseInterruptedNotificationClaims("me", window = Long.MAX_VALUE / 2, maxRows = 2)
+
+            assertEquals(listOf(middle, newest), dao.pendingNotifications(10, window = Long.MAX_VALUE / 2, maxRows = 2).map { it.id })
+            assertEquals(0, dao.claimNotification(oldest, "me"))
+        }
+}

--- a/app/src/test/kotlin/io/github/trevarj/motd/data/sync/CanonicalTimelineStoreTest.kt
+++ b/app/src/test/kotlin/io/github/trevarj/motd/data/sync/CanonicalTimelineStoreTest.kt
@@ -557,7 +557,7 @@ class CanonicalTimelineStoreTest {
                 listOf(older.event.id),
                 setup.db
                     .canonicalTimelineDao()
-                    .pendingNotifications(10)
+                    .pendingNotifications(10, window = Long.MAX_VALUE / 2, maxRows = Int.MAX_VALUE)
                     .map { it.id },
             )
             setup.db.close()
@@ -576,10 +576,12 @@ class CanonicalTimelineStoreTest {
 
             setup.db.canonicalTimelineDao().releaseInterruptedNotificationClaims(
                 NotificationClaimSession.owner,
+                window = Long.MAX_VALUE / 2,
+                maxRows = Int.MAX_VALUE,
             )
             assertEquals(false, setup.store.claimNotification(event.event.id))
 
-            setup.db.canonicalTimelineDao().releaseInterruptedNotificationClaims("next-process")
+            setup.db.canonicalTimelineDao().releaseInterruptedNotificationClaims("next-process", window = Long.MAX_VALUE / 2, maxRows = Int.MAX_VALUE)
             assertEquals(true, setup.store.claimNotification(event.event.id))
             setup.db.close()
         }


### PR DESCRIPTION
## Summary

Cold start on a large local database was slow because two notification-recovery queries scanned the entire `messages` table on every process start. This bounds both scans to a small index range.

## Root cause

`MotdNotifications` runs `releaseInterruptedNotificationClaims` and `pendingNotifications` from its `init` block, i.e. at process start. Both filter on `notificationHandled = 0 AND notificationClaimed = 0`, and `notificationHandled` only ever flips to `1` one row at a time (`completeNotification`), so on an archive of any size **~100 % of rows match the flag predicates**. No index leads with those columns, and `pendingNotifications` additionally orders by `serverTime`, so SQLite does a full table scan plus a temp b-tree sort — `LIMIT 200` bounds nothing.

Measured on a synthetic database built from the real v39 schema (1.5 GB, 3.6 M rows, 60 rooms), warm cache, desktop NVMe — i.e. a floor for a phone:

| query | before | after |
|---|---|---|
| `pendingNotifications(200)` | 7 628 ms (`SCAN m` + temp b-tree) | 16 ms |
| `releaseInterruptedNotificationClaims` | 611 ms (`SCAN messages`) | 17 ms |

## Change

Both queries are floored at

```sql
serverTime >= MAX((SELECT MAX(serverTime) FROM messages) - :window,
                  COALESCE((SELECT serverTime FROM messages
                            ORDER BY serverTime DESC LIMIT 1 OFFSET :maxRows - 1), 0))
```

with `window = 48 h` and `maxRows = 5000` (`MotdNotifications.RECOVERY_WINDOW_MS` / `RECOVERY_SCAN_ROWS`). The floor is anchored on stored `serverTime`s rather than the wall clock, so a wrong device clock or odd server timestamps can't push it past the rows that matter; the row cap keeps a flooding channel from stretching the time window. `index_messages_serverTime_id` serves the range. Recovery only ever re-presents a crash-interrupted notification, which by construction sits among the newest rows, so the floor drops nothing real.

## Verification

- New `NotificationRecoveryDaoTest`: an unhandled LIVE event outside the window is neither released nor returned; one inside is; an unbounded window releases the stale one (proves the window, not claim state, gated it); the row cap is honoured even inside the time window (this case caught an off-by-one in `OFFSET` during development).
- `CanonicalTimelineStoreTest`, `AllMigrationsTest`, `MotdNotificationsAlertingTest`, `MotdNotificationsFoolTest` pass; existing callers use an unbounded window so their claim-semantics coverage is unchanged.
- `:app:ktlintCheck` clean.

No schema change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
